### PR TITLE
#251: refactor nodeTreeView

### DIFF
--- a/src/components/main/actionsPanel/nodeTreeView/hooks/useCmdk.ts
+++ b/src/components/main/actionsPanel/nodeTreeView/hooks/useCmdk.ts
@@ -1,0 +1,69 @@
+import { useContext, useEffect } from "react";
+import { AddNodeActionPrefix } from "@_constants/main";
+import { MainContext } from "@_redux/main";
+import { useNodeActionsHandlers } from "./useNodeActionsHendlers";
+
+export const useCmdk = () => {
+  const {
+    // node actions
+    activePanel,
+    // cmdk
+    currentCommand,
+    // other
+    theme: _theme,
+  } = useContext(MainContext);
+
+  const {
+    onCut,
+    onCopy,
+    onPaste,
+    onDelete,
+    onDuplicate,
+    onTurnInto,
+    onGroup,
+    onUngroup,
+    onAddNode,
+  } = useNodeActionsHandlers();
+
+  const isAddNodeAction = (actionName: string): boolean => {
+    return actionName.startsWith(AddNodeActionPrefix) ? true : false;
+  };
+
+  useEffect(() => {
+    if (isAddNodeAction(currentCommand.action)) {
+      onAddNode(currentCommand.action);
+      return;
+    }
+
+    if (activePanel !== "node" && activePanel !== "stage") return;
+
+    switch (currentCommand.action) {
+      case "Cut":
+        onCut();
+        break;
+      case "Copy":
+        onCopy();
+        break;
+      case "Paste":
+        onPaste();
+        break;
+      case "Delete":
+        onDelete();
+        break;
+      case "Duplicate":
+        onDuplicate();
+        break;
+      case "Turn into":
+        onTurnInto();
+        break;
+      case "Group":
+        onGroup();
+        break;
+      case "Ungroup":
+        onUngroup();
+        break;
+      default:
+        break;
+    }
+  }, [currentCommand]);
+};

--- a/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeTreeCallback.ts
+++ b/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeTreeCallback.ts
@@ -1,4 +1,3 @@
-import { Ref } from "react";
 import { DraggingPosition, TreeItem, TreeItemIndex } from "react-complex-tree";
 
 import { TNodeUid } from "@_node/types";
@@ -7,13 +6,13 @@ import { useNodeActions } from "./useNodeActions";
 import { useNodeViewState } from "./useNodeViewState";
 
 export const useNodeTreeCallback = (
-  focusedItemRef: Ref<TNodeUid> | null,
-  isDragging: React.MutableRefObject<boolean>,
+  focusItemValue: TNodeUid | null,
+  isDragging: boolean,
 ) => {
   const { cb_moveNode } = useNodeActions();
 
   const { cb_focusNode, cb_selectNode, cb_expandNode, cb_collapseNode } =
-    useNodeViewState(focusedItemRef);
+    useNodeViewState(focusItemValue);
 
   const onSelectItems = (items: TreeItemIndex[]) => {
     cb_selectNode(items as TNodeUid[]);
@@ -41,7 +40,7 @@ export const useNodeTreeCallback = (
 
     cb_moveNode(uids, targetUid, isBetween, position);
 
-    isDragging.current = false;
+    isDragging = false;
 
     const className = "dragging-tree";
     const html = document.getElementsByTagName("html").item(0);

--- a/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeViewState.ts
+++ b/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeViewState.ts
@@ -17,7 +17,7 @@ import {
 
 import { HmsClearActionType } from "@_constants/main";
 
-export function useNodeViewState(focusedItemRef: any) {
+export function useNodeViewState(focusItemValue: TNodeUid | null) {
   const dispatch = useDispatch();
   const { focusedItem, selectedItems, selectedItemsObj } =
     useSelector(fnSelector);
@@ -51,7 +51,7 @@ export function useNodeViewState(focusedItemRef: any) {
       }
 
       dispatch(focusFNNode(uid));
-      focusedItemRef.current = uid;
+      focusItemValue = uid;
 
       removeRunningActions(["nodeTreeView-focus"]);
     },

--- a/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/Container.tsx
+++ b/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/Container.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from "react";
+
+interface ContainerProps {
+  children: React.ReactNode;
+  containerProps: React.HTMLProps<any>;
+}
+
+export const Container: FC<ContainerProps> = React.memo(
+  ({ containerProps, children }) => {
+    return <ul {...containerProps}>{children}</ul>;
+  },
+);

--- a/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/DragBetweenLine.tsx
+++ b/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/DragBetweenLine.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from "react";
+import { DraggingPosition } from "react-complex-tree";
+
+interface DragBetweenLine {
+  draggingPosition: DraggingPosition;
+  lineProps: React.HTMLProps<any>;
+}
+
+export const DragBetweenLine: FC<DragBetweenLine> = React.memo(
+  ({ draggingPosition, lineProps }) => {
+    return (
+      <div
+        {...lineProps}
+        className={"foreground-tertiary"}
+        style={{
+          position: "absolute",
+          right: "0",
+          top:
+            draggingPosition.targetType === "between-items" &&
+            draggingPosition.linePosition === "top"
+              ? "0px"
+              : draggingPosition.targetType === "between-items" &&
+                draggingPosition.linePosition === "bottom"
+              ? "-2px"
+              : "-2px",
+          left: `${draggingPosition.depth * 10 + 20}px`,
+          height: "2px",
+        }}
+      />
+    );
+  },
+);

--- a/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/ItemArrow.tsx
+++ b/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/ItemArrow.tsx
@@ -1,0 +1,46 @@
+import React, { FC, useCallback } from "react";
+import { SVGIconI, SVGIconII } from "@_components/common";
+import { TreeItem, TreeItemRenderContext } from "react-complex-tree";
+
+interface ItemArrowProps {
+  item: TreeItem<any>;
+  context: TreeItemRenderContext<never>;
+  addRunningActions: (actionNames: string[]) => void;
+}
+
+export const ItemArrow: FC<ItemArrowProps> = React.memo(
+  ({ item, context, addRunningActions }) => {
+    const onClick = useCallback(() => {
+      addRunningActions(["nodeTreeView-arrow"]);
+      context.toggleExpandedState();
+    }, [context]);
+
+    return (
+      <>
+        {item.isFolder ? (
+          context.isExpanded ? (
+            <SVGIconI
+              {...{
+                class: "icon-xs",
+                onClick,
+              }}
+            >
+              down
+            </SVGIconI>
+          ) : (
+            <SVGIconII
+              {...{
+                class: "icon-xs",
+                onClick,
+              }}
+            >
+              right
+            </SVGIconII>
+          )
+        ) : (
+          <div className="icon-xs" />
+        )}
+      </>
+    );
+  },
+);

--- a/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/ItemTitle.tsx
+++ b/src/components/main/actionsPanel/nodeTreeView/nodeTreeComponents/ItemTitle.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from "react";
+
+interface ItemTitleProps {
+  title: string;
+}
+
+export const ItemTitle: FC<ItemTitleProps> = React.memo(({ title }) => {
+  return (
+    <span
+      className="text-s justify-stretch"
+      style={{
+        width: "calc(100% - 32px)",
+        textOverflow: "ellipsis",
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {title}
+    </span>
+  );
+});


### PR DESCRIPTION
There business logic and presentation were separated.
TreeView component props were separated from component and a reusable component was created for each component.

But one component was not separated (renderItem) because it caused optimization problems. These problems are because we have a fnHoveredItem, each fnHoveredItem changes causing unnecessary re-renders, its re-renders happen because we add or remove a class in the node component. Perhaps a better way to optimize is to use hover pseudo-classes to change the representation of the hovered node and not to use js to change the representation of the  hovered node elements.

This can help to optimize the component that is passed in renderItem and we can separate that component or we can leave it in the existing place and return to that element later.