### PR TITLE
536 file self DnD

### DIFF
--- a/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
+++ b/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
@@ -472,8 +472,6 @@ export default function WorkspaceTreeView() {
               const targetUid = (target as DraggingPositionItem)
                 .targetItem as TNodeUid;
               if (invalidFileNodes[targetUid]) return;
-              console.log(targetUid, "### targetUid");
-
               const uids = items
                 .map((item) => item.index as TNodeUid)
                 .filter(

--- a/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
+++ b/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
@@ -472,9 +472,15 @@ export default function WorkspaceTreeView() {
               const targetUid = (target as DraggingPositionItem)
                 .targetItem as TNodeUid;
               if (invalidFileNodes[targetUid]) return;
+              console.log(targetUid, "### targetUid");
+
               const uids = items
                 .map((item) => item.index as TNodeUid)
-                .filter((uid) => !invalidFileNodes[uid]);
+                .filter(
+                  (uid) =>
+                    !invalidFileNodes[uid] &&
+                    fileTree[uid].parentUid !== targetUid,
+                );
               if (uids.length === 0) return;
 
               cb_moveNode(uids, targetUid);


### PR DESCRIPTION
Prevented drag files in current folder. 

In task added description to adding it for node-tree too, but if we move nodes in the node-tree in the current parent node, it might be a desirable action to change the location of the node because it affects the view in the stage and has different logic than file-tree.