### PR TITLE
176-Routing

### DIFF
--- a/src/_node/file/helpers.ts
+++ b/src/_node/file/helpers.ts
@@ -148,3 +148,10 @@ export const getTargetHandler = ({
   }
   return targetHandler;
 };
+export const createURLPath = (
+  baseString: string,
+  partToReplace: string,
+  replacementValue: string,
+) => {
+  return baseString?.replace(partToReplace, replacementValue);
+};

--- a/src/_node/file/helpers.ts
+++ b/src/_node/file/helpers.ts
@@ -153,5 +153,5 @@ export const createURLPath = (
   partToReplace: string,
   replacementValue: string,
 ) => {
-  return baseString?.replace(partToReplace, replacementValue);
+  return `/${baseString?.replace(partToReplace, replacementValue)}`;
 };

--- a/src/_redux/main/context.ts
+++ b/src/_redux/main/context.ts
@@ -1,9 +1,6 @@
-import {
-  Context,
-  createContext,
-} from 'react';
+import { Context, createContext } from "react";
 
-import { TMainContext } from './types';
+import { TMainContext } from "./types";
 
 export const MainContext: Context<TMainContext> = createContext<TMainContext>({
   addRunningActions: () => {},
@@ -21,6 +18,10 @@ export const MainContext: Context<TMainContext> = createContext<TMainContext>({
   setCurrentProjectFileHandle: () => {},
   fileHandlers: {},
   setFileHandlers: () => {},
+
+  recentProjectNames: [],
+  recentProjectHandlers: [],
+  recentProjectContexts: [],
 
   monacoEditorRef: { current: null },
   setMonacoEditorRef: () => {},

--- a/src/_redux/main/types.ts
+++ b/src/_redux/main/types.ts
@@ -74,6 +74,7 @@ export type TMainContext = {
   importProject: (
     fsType: TProjectContext,
     projectHandle?: FileSystemDirectoryHandle | null,
+    fromURL?: boolean,
   ) => void;
   reloadCurrentProject: (action?: TFileAction) => void;
   triggerCurrentProjectReload: () => void;

--- a/src/_redux/main/types.ts
+++ b/src/_redux/main/types.ts
@@ -1,19 +1,16 @@
-import { MutableRefObject } from 'react';
+import { MutableRefObject } from "react";
 
-import { editor } from 'monaco-editor';
+import { editor } from "monaco-editor";
 
-import { TFileHandlerCollection } from '@_node/file';
-import { TNodeUid } from '@_node/types';
+import { TFileHandlerCollection } from "@_node/file";
+import { TNodeUid } from "@_node/types";
 import {
   TCmdkReferenceData,
   TFilesReferenceData,
   THtmlReferenceData,
-} from '@_types/main';
+} from "@_types/main";
 
-import {
-  TFileAction,
-  TProjectContext,
-} from './fileTree';
+import { TFileAction, TProjectContext } from "./fileTree";
 
 export type TEventHistoryInfo = {
   future: number;
@@ -52,6 +49,10 @@ export type TMainContext = {
   ) => void;
   fileHandlers: TFileHandlerCollection;
   setFileHandlers: (fileHandlerObj: TFileHandlerCollection) => void;
+
+  recentProjectNames: string[];
+  recentProjectHandlers: (FileSystemDirectoryHandle | null)[];
+  recentProjectContexts: TProjectContext[];
 
   monacoEditorRef: IEditorRef;
   setMonacoEditorRef: (

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { HashRouter as Router, Route, Routes } from "react-router-dom";
 import { Workbox } from "workbox-window";
 
 import { LogAllow } from "@_constants/global";
@@ -27,7 +27,7 @@ export default function App(props: AppProps) {
         {nohostReady ? (
           <Router>
             <Routes>
-              <Route path="/" element={<MainPage />} />
+              <Route path="*" element={<MainPage />} />
             </Routes>
           </Router>
         ) : null}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -27,7 +27,8 @@ export default function App(props: AppProps) {
         {nohostReady ? (
           <Router>
             <Routes>
-              <Route path="*" element={<MainPage />} />
+              <Route path="/" element={<MainPage />} />
+              <Route path="/:project/*" element={<MainPage />} />
             </Routes>
           </Router>
         ) : null}

--- a/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
+++ b/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
@@ -10,9 +10,11 @@ import cx from "classnames";
 import { debounce } from "lodash";
 import { DraggingPositionItem } from "react-complex-tree";
 import { useDispatch } from "react-redux";
+import { useNavigate, useParams } from "react-router-dom";
 
+import { RootNodeUid } from "@_constants/main";
 import { SVGIconI, SVGIconII, TreeView } from "@_components/common";
-import { getNormalizedPath, TFileNodeData } from "@_node/file";
+import { getNormalizedPath, createURLPath, TFileNodeData } from "@_node/file";
 import { _path } from "@_node/file/nohostApis";
 import { TNode, TNodeUid } from "@_node/types";
 import { MainContext } from "@_redux/main";
@@ -56,6 +58,8 @@ export default function WorkspaceTreeView() {
     filesReferenceData,
     invalidFileNodes,
   } = useContext(MainContext);
+  const navigate = useNavigate();
+  const path = useParams();
 
   const { focusedItemRef, fileTreeViewData } = useSync();
   const { cb_focusNode, cb_selectNode, cb_expandNode, cb_collapseNode } =
@@ -135,6 +139,18 @@ export default function WorkspaceTreeView() {
     dispatch(setActivePanel("file"));
   }, []);
 
+  useEffect(() => {
+    if (!path["*"]) return;
+    const pathName = createURLPath(
+      path["*"],
+      fileTree[RootNodeUid]?.displayName,
+      RootNodeUid,
+    );
+    if (currentFileUid !== pathName) {
+      openFile(pathName);
+    }
+  }, [path]);
+
   return currentFileUid === "" || navigatorDropdownType === "project" ? (
     <>
       <div
@@ -199,6 +215,14 @@ export default function WorkspaceTreeView() {
                   e.stopPropagation();
                   const isFile =
                     fileTree[props.item.data.uid].data.kind === "file";
+                  isFile &&
+                    navigate(
+                      createURLPath(
+                        props.item.data.uid,
+                        RootNodeUid,
+                        fileTree[RootNodeUid]?.displayName,
+                      ),
+                    );
 
                   isFile &&
                     props.item.data.uid !== currentFileUid &&

--- a/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
+++ b/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
@@ -42,6 +42,7 @@ import {
   useSync,
 } from "./hooks";
 import { useSaveCommand } from "@_pages/main/processor/hooks";
+import { LogAllow } from "@_constants/global";
 
 const AutoExpandDelayOnDnD = 1 * 1000;
 export default function WorkspaceTreeView() {
@@ -148,56 +149,53 @@ export default function WorkspaceTreeView() {
   const onPanelClick = useCallback(() => {
     dispatch(setActivePanel("file"));
   }, []);
-  const openFromURL = async () => {
-    console.log(">>>>>>>>>>>>>>>>>>>> function to be run <<<<<<<<<<<<<<<<<<");
 
+  const openFromURL = async () => {
     if (!project) return;
-    if (currentProjectFileHandle?.name !== project) {
-      // if (recentProjectNames.includes(project)) {
-      console.log({ recentProjectContexts, recentProjectHandlers });
+    const pathName = `${RootNodeUid}/${rest}`;
+
+    if (
+      currentProjectFileHandle &&
+      currentProjectFileHandle?.name !== project
+    ) {
+      console.log(
+        recentProjectHandlers,
+        "recentProjectHandlers",
+        currentProjectFileHandle?.name,
+        project,
+        "currentProjectFileHandle?.name !== project",
+      );
+
+      if (!recentProjectHandlers) return;
 
       const index = recentProjectNames.indexOf(project);
-
-      console.log({ project, rest, index }, "index");
-
       const projectContext = recentProjectContexts[index];
       const projectHandler = recentProjectHandlers[index];
 
-      console.log(
-        { projectContext, projectHandler },
-        "recentProjectHandlers[index]",
-      );
-
       if (index >= 0 && projectHandler) {
-        confirmFileChanges(fileTree) &&
-          importProject(projectContext, projectHandler);
+        if (!confirmFileChanges(fileTree)) return;
+        if (project !== projectHandler.name) {
+          try {
+            importProject(projectContext, projectHandler);
+          } catch {
+            LogAllow && console.log("failed to open local project");
+          }
+        }
+
+        // dispatch(setInitialFileUidToOpen(pathName));
       }
     }
 
-    const pathName = `${RootNodeUid}/${rest}`;
-    if (currentFileUid !== pathName) {
+    if (currentFileUid && currentFileUid !== pathName) {
+      console.log({ currentFileUid, pathName }, "currentFileUid !== pathName");
+
       openFile(pathName);
     }
   };
+
   useEffect(() => {
-    // if (!project) return;
-    // if (currentProjectFileHandle?.name !== project) {
-    //   // if (recentProjectNames.includes(project)) {
-    //   const index = recentProjectNames.indexOf(project);
-    //   if (index >= 0) {
-    //     confirmFileChanges(fileTree) &&
-    //       importProject(
-    //         recentProjectContexts[index],
-    //         recentProjectHandlers[index],
-    //       );
-    //   }
-    // }
-    // const pathName = `${RootNodeUid}/${rest}`;
-    // if (currentFileUid !== pathName) {
-    //   openFile(pathName);
-    // }
-    // openFromURL();
-  }, [project, rest]);
+    openFromURL();
+  }, [project, rest, recentProjectHandlers]);
 
   return currentFileUid === "" || navigatorDropdownType === "project" ? (
     <>

--- a/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
+++ b/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
@@ -42,7 +42,6 @@ import {
   useSync,
 } from "./hooks";
 import { useSaveCommand } from "@_pages/main/processor/hooks";
-import { LogAllow } from "@_constants/global";
 
 const AutoExpandDelayOnDnD = 1 * 1000;
 export default function WorkspaceTreeView() {
@@ -158,14 +157,6 @@ export default function WorkspaceTreeView() {
       currentProjectFileHandle &&
       currentProjectFileHandle?.name !== project
     ) {
-      console.log(
-        recentProjectHandlers,
-        "recentProjectHandlers",
-        currentProjectFileHandle?.name,
-        project,
-        "currentProjectFileHandle?.name !== project",
-      );
-
       if (!recentProjectHandlers) return;
 
       const index = recentProjectNames.indexOf(project);
@@ -173,23 +164,15 @@ export default function WorkspaceTreeView() {
       const projectHandler = recentProjectHandlers[index];
 
       if (index >= 0 && projectHandler) {
-        if (!confirmFileChanges(fileTree)) return;
-        if (project !== projectHandler.name) {
-          try {
-            importProject(projectContext, projectHandler);
-          } catch {
-            LogAllow && console.log("failed to open local project");
-          }
+        if (currentFileUid !== projectHandler.name) {
+          confirmFileChanges(fileTree) &&
+            importProject(projectContext, projectHandler, true);
         }
-
-        // dispatch(setInitialFileUidToOpen(pathName));
       }
-    }
 
-    if (currentFileUid && currentFileUid !== pathName) {
-      console.log({ currentFileUid, pathName }, "currentFileUid !== pathName");
-
-      openFile(pathName);
+      if (currentFileUid && currentFileUid !== pathName) {
+        openFile(pathName);
+      }
     }
   };
 

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -12,6 +12,7 @@ import {
   RenderableFileTypes,
   CodeViewSyncDelay,
   RenameActionPrefix,
+  RootNodeUid,
 } from "@_constants/main";
 import {
   confirmFileChanges,
@@ -45,6 +46,7 @@ import {
 } from "./hooks";
 import Processor from "./processor";
 import { debounce } from "lodash";
+import { useNavigate, useParams } from "react-router-dom";
 
 export default function MainPage() {
   // redux
@@ -81,6 +83,7 @@ export default function MainPage() {
     setRecentProjectNames,
     setRecentProjectHandlers,
   } = useRecentProjects();
+
   const { filesReferenceData, htmlReferenceData } = useReferenceData();
   const {
     monacoEditorRef,
@@ -243,7 +246,66 @@ export default function MainPage() {
       removeEventListeners();
     };
   }, [addEventListeners, removeEventListeners]);
+  const { project, "*": rest } = useParams();
+  const navigate = useNavigate();
 
+  const openFromURL = async () => {
+    console.log(">>>>>>>>>>>>>>>>>>>> function to be run <<<<<<<<<<<<<<<<<<");
+
+    if (!project) return;
+    if (currentProjectFileHandle?.name !== project) {
+      // if (recentProjectNames.includes(project)) {
+      console.log({ recentProjectContexts, recentProjectHandlers });
+
+      const index = recentProjectNames.indexOf(project);
+
+      console.log({ project, rest, index }, "index");
+
+      const projectContext = recentProjectContexts[index];
+      const projectHandler = recentProjectHandlers[index];
+
+      console.log(
+        { projectContext, projectHandler },
+        "recentProjectHandlers[index]",
+      );
+
+      if (index >= 0 && projectHandler) {
+        // isUnsavedProject(fileTree)
+        //   ? confirmFileChanges(fileTree)
+        //   :
+        // window.confirm("Дозволити доступ до файлу?") &&
+        importProject(projectContext, projectHandler);
+      }
+    }
+
+    const pathName = `${RootNodeUid}/${rest}`;
+    if (currentFileUid !== pathName) {
+      console.log(pathName, "openFILE");
+
+      // openFile(pathName);
+    }
+  };
+  useEffect(() => {
+    // if (!project) return;
+    // if (currentProjectFileHandle?.name !== project) {
+    //   // if (recentProjectNames.includes(project)) {
+    //   const index = recentProjectNames.indexOf(project);
+
+    //   if (index >= 0) {
+    //     confirmFileChanges(fileTree) &&
+    //       importProject(
+    //         recentProjectContexts[index],
+    //         recentProjectHandlers[index],
+    //       );
+    //   }
+    // }
+
+    // const pathName = `${RootNodeUid}/${rest}`;
+    // if (currentFileUid !== pathName) {
+    //   openFile(pathName);
+    // }
+    recentProjectHandlers && openFromURL();
+  }, [project, rest, recentProjectHandlers]);
   return (
     <>
       <MainContext.Provider
@@ -262,7 +324,12 @@ export default function MainPage() {
           fileHandlers,
           setFileHandlers,
 
+          recentProjectNames,
+          recentProjectHandlers,
+          recentProjectContexts,
+
           monacoEditorRef,
+
           setMonacoEditorRef,
           iframeRefRef,
           setIframeRefRef,
@@ -545,10 +612,12 @@ export default function MainPage() {
                                   command.Group === "Recent"
                                 ) {
                                   const index = Number(command.Context);
+
                                   const projectContext =
                                     recentProjectContexts[index];
                                   const projectHandler =
                                     recentProjectHandlers[index];
+                                  navigate("/");
 
                                   confirmFileChanges(fileTree) &&
                                     importProject(

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -12,7 +12,6 @@ import {
   RenderableFileTypes,
   CodeViewSyncDelay,
   RenameActionPrefix,
-  RootNodeUid,
 } from "@_constants/main";
 import {
   confirmFileChanges,
@@ -46,7 +45,7 @@ import {
 } from "./hooks";
 import Processor from "./processor";
 import { debounce } from "lodash";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function MainPage() {
   // redux
@@ -246,66 +245,8 @@ export default function MainPage() {
       removeEventListeners();
     };
   }, [addEventListeners, removeEventListeners]);
-  const { project, "*": rest } = useParams();
   const navigate = useNavigate();
 
-  const openFromURL = async () => {
-    console.log(">>>>>>>>>>>>>>>>>>>> function to be run <<<<<<<<<<<<<<<<<<");
-
-    if (!project) return;
-    if (currentProjectFileHandle?.name !== project) {
-      // if (recentProjectNames.includes(project)) {
-      console.log({ recentProjectContexts, recentProjectHandlers });
-
-      const index = recentProjectNames.indexOf(project);
-
-      console.log({ project, rest, index }, "index");
-
-      const projectContext = recentProjectContexts[index];
-      const projectHandler = recentProjectHandlers[index];
-
-      console.log(
-        { projectContext, projectHandler },
-        "recentProjectHandlers[index]",
-      );
-
-      if (index >= 0 && projectHandler) {
-        // isUnsavedProject(fileTree)
-        //   ? confirmFileChanges(fileTree)
-        //   :
-        // window.confirm("Дозволити доступ до файлу?") &&
-        importProject(projectContext, projectHandler);
-      }
-    }
-
-    const pathName = `${RootNodeUid}/${rest}`;
-    if (currentFileUid !== pathName) {
-      console.log(pathName, "openFILE");
-
-      // openFile(pathName);
-    }
-  };
-  useEffect(() => {
-    // if (!project) return;
-    // if (currentProjectFileHandle?.name !== project) {
-    //   // if (recentProjectNames.includes(project)) {
-    //   const index = recentProjectNames.indexOf(project);
-
-    //   if (index >= 0) {
-    //     confirmFileChanges(fileTree) &&
-    //       importProject(
-    //         recentProjectContexts[index],
-    //         recentProjectHandlers[index],
-    //       );
-    //   }
-    // }
-
-    // const pathName = `${RootNodeUid}/${rest}`;
-    // if (currentFileUid !== pathName) {
-    //   openFile(pathName);
-    // }
-    recentProjectHandlers && openFromURL();
-  }, [project, rest, recentProjectHandlers]);
   return (
     <>
       <MainContext.Provider
@@ -581,7 +522,7 @@ export default function MainPage() {
                                 "rnbw-cmdk-menu-item-description":
                                   command.Description,
                               }}
-                              onSelect={() => {
+                              onSelect={async () => {
                                 LogAllow && console.log("onSelect", command);
 
                                 // keep modal open when toogling theme or go "Add" menu from "Actions" menu

--- a/src/pages/main/hooks/useCmdk.ts
+++ b/src/pages/main/hooks/useCmdk.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect } from "react";
 import { CustomDirectoryPickerOptions } from "file-system-access/lib/showDirectoryPicker";
 import { delMany } from "idb-keyval";
 import { useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 import { LogAllow } from "@_constants/global";
 import { DefaultProjectPath } from "@_constants/main";
@@ -46,6 +47,8 @@ interface IUseCmdk {
 }
 export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
+
   const {
     osType,
     theme,
@@ -86,6 +89,7 @@ export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
 
     dispatch(setDoingFileAction(true));
     try {
+      navigate("/");
       await initIDBProject(DefaultProjectPath);
       await importProject("idb");
     } catch (err) {
@@ -98,6 +102,7 @@ export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
 
     dispatch(setDoingFileAction(true));
     try {
+      navigate("/", { replace: true });
       const projectHandle = await showDirectoryPicker({
         _preferPolyfill: false,
         mode: "readwrite",
@@ -107,7 +112,7 @@ export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
       LogAllow && console.log("failed to open local project");
     }
     dispatch(setDoingFileAction(false));
-  }, [importProject, fileTree]);
+  }, [importProject, fileTree, navigate]);
   const onActions = useCallback(() => {
     if (cmdkOpen) return;
     dispatch(setCmdkPages(["Actions"]));

--- a/src/pages/main/hooks/useCmdk.ts
+++ b/src/pages/main/hooks/useCmdk.ts
@@ -89,7 +89,6 @@ export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
 
     dispatch(setDoingFileAction(true));
     try {
-      navigate("/");
       await initIDBProject(DefaultProjectPath);
       await importProject("idb");
     } catch (err) {
@@ -101,8 +100,8 @@ export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
     if (!confirmFileChanges(fileTree)) return;
 
     dispatch(setDoingFileAction(true));
+    navigate("/");
     try {
-      navigate("/", { replace: true });
       const projectHandle = await showDirectoryPicker({
         _preferPolyfill: false,
         mode: "readwrite",

--- a/src/pages/main/hooks/useHandlers.ts
+++ b/src/pages/main/hooks/useHandlers.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { setMany } from "idb-keyval";
 import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { LogAllow } from "@_constants/global";
 import {
@@ -69,6 +69,8 @@ export const useHandlers = ({
   const navigate = useNavigate();
   const { osType, navigatorDropdownType, project, fileTree, currentFileUid } =
     useAppState();
+
+  const { "*": rest } = useParams();
 
   const saveRecentProject = useCallback(
     async (
@@ -162,9 +164,10 @@ export const useHandlers = ({
             fsType,
             projectHandle as FileSystemDirectoryHandle,
           );
+          console.log(rest, "rest");
 
           const pathURL = createURLPath(
-            _initialFileUidToOpen,
+            rest ? `${RootNodeUid}/${rest}` : _initialFileUidToOpen,
             RootNodeUid,
             _fileTree[RootNodeUid]?.displayName,
           );

--- a/src/pages/main/hooks/useHandlers.ts
+++ b/src/pages/main/hooks/useHandlers.ts
@@ -2,11 +2,17 @@ import { useCallback, useEffect, useState } from "react";
 
 import { setMany } from "idb-keyval";
 import { useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
 import { LogAllow } from "@_constants/global";
-import { DefaultProjectPath, RecentProjectCount } from "@_constants/main";
+import {
+  DefaultProjectPath,
+  RecentProjectCount,
+  RootNodeUid,
+} from "@_constants/main";
 import {
   buildNohostIDB,
+  createURLPath,
   loadIDBProject,
   loadLocalProject,
   TFileHandlerCollection,
@@ -60,6 +66,7 @@ export const useHandlers = ({
   setRecentProjectHandlers,
 }: IUseHandlers) => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { osType, navigatorDropdownType, project, fileTree, currentFileUid } =
     useAppState();
 
@@ -154,6 +161,13 @@ export const useHandlers = ({
           await saveRecentProject(
             fsType,
             projectHandle as FileSystemDirectoryHandle,
+          );
+          navigate(
+            createURLPath(
+              _initialFileUidToOpen,
+              RootNodeUid,
+              _fileTree[RootNodeUid]?.displayName,
+            ),
           );
         } catch (err) {
           LogAllow && console.log("ERROR while importing local project", err);

--- a/src/pages/main/hooks/useHandlers.ts
+++ b/src/pages/main/hooks/useHandlers.ts
@@ -119,6 +119,7 @@ export const useHandlers = ({
     async (
       fsType: TProjectContext,
       projectHandle?: FileSystemDirectoryHandle | null,
+      fromURL?: boolean,
     ) => {
       if (fsType === "local") {
         dispatch(setDoingFileAction(true));
@@ -164,10 +165,9 @@ export const useHandlers = ({
             fsType,
             projectHandle as FileSystemDirectoryHandle,
           );
-          console.log(rest, "rest");
 
           const pathURL = createURLPath(
-            rest ? `${RootNodeUid}/${rest}` : _initialFileUidToOpen,
+            fromURL ? `${RootNodeUid}/${rest}` : _initialFileUidToOpen,
             RootNodeUid,
             _fileTree[RootNodeUid]?.displayName,
           );
@@ -207,7 +207,7 @@ export const useHandlers = ({
         dispatch(setLoadingFalse());
       }
     },
-    [osType, saveRecentProject],
+    [osType, saveRecentProject, rest],
   );
 
   // current project - reload trigger

--- a/src/pages/main/hooks/useHandlers.ts
+++ b/src/pages/main/hooks/useHandlers.ts
@@ -162,13 +162,13 @@ export const useHandlers = ({
             fsType,
             projectHandle as FileSystemDirectoryHandle,
           );
-          navigate(
-            createURLPath(
-              _initialFileUidToOpen,
-              RootNodeUid,
-              _fileTree[RootNodeUid]?.displayName,
-            ),
+
+          const pathURL = createURLPath(
+            _initialFileUidToOpen,
+            RootNodeUid,
+            _fileTree[RootNodeUid]?.displayName,
           );
+          navigate(pathURL);
         } catch (err) {
           LogAllow && console.log("ERROR while importing local project", err);
         }


### PR DESCRIPTION
HashRouter used to handle the routing.
When a user manually enters a URL or refreshes the page, the browser doesn't receive the part after the hash (#/path), but if we use BrowserRouter browser sees the entire path, and if the page doesn't exist, throws an error. 
HashRouter was used to avoid errors and unexpected behavior.
Now paths looks like: http://localhost:8080/#/rnbw.company/index.html

When we change the file, the path also changes, and when we change the path, the required file is opened.