### PR TITLE
WC open issues

### DIFF
--- a/src/components/main/codeView/CodeView.tsx
+++ b/src/components/main/codeView/CodeView.tsx
@@ -104,6 +104,7 @@ export default function CodeView(props: CodeViewProps) {
       1,
     );
   }, [validNodeTree, nFocusedItem, activePanel]);
+
   useEffect(() => {
     const monacoEditor = monacoEditorRef.current;
     if (!monacoEditor) return;
@@ -163,6 +164,9 @@ export default function CodeView(props: CodeViewProps) {
 
     const file = fileTree[currentFileUid];
     if (!file) return;
+
+    const ext = file.data.ext;
+    if (ext !== "html") return;
 
     if (!validNodeTree[RootNodeUid]) return;
 

--- a/src/components/main/codeView/CodeView.tsx
+++ b/src/components/main/codeView/CodeView.tsx
@@ -70,10 +70,9 @@ export default function CodeView(props: CodeViewProps) {
     const extension = fileData.ext;
     extension && updateLanguage(extension);
 
+    //scroll to top
     const monacoEditor = monacoEditorRef.current;
     if (!monacoEditor) return;
-
-    //scroll to top
     monacoEditor.setScrollTop(0);
   }, [fileTree, currentFileUid]);
 

--- a/src/components/main/codeView/CodeView.tsx
+++ b/src/components/main/codeView/CodeView.tsx
@@ -69,10 +69,17 @@ export default function CodeView(props: CodeViewProps) {
     const fileData = file.data as TFileNodeData;
     const extension = fileData.ext;
     extension && updateLanguage(extension);
+
+    const monacoEditor = monacoEditorRef.current;
+    if (!monacoEditor) return;
+
+    //scroll to top
+    monacoEditor.setScrollTop(0);
   }, [fileTree, currentFileUid]);
 
   // focusedItem -> code select
   const focusedItemRef = useRef<TNodeUid>("");
+
   const hightlightFocusedNodeSourceCode = useCallback(() => {
     const monacoEditor = monacoEditorRef.current;
     if (!monacoEditor) return;

--- a/src/components/main/codeView/hooks/useEditor.ts
+++ b/src/components/main/codeView/hooks/useEditor.ts
@@ -88,9 +88,11 @@ const useEditor = () => {
     null,
   );
   const codeSelectionRef = useRef<TCodeSelection | null>(null);
+
   useEffect(() => {
     codeSelectionRef.current = codeSelection;
   }, [codeSelection]);
+
   const setCodeSelection = useCallback(() => {
     const monacoEditor = monacoEditorRef.current;
     const _selection = monacoEditor?.getSelection();
@@ -129,7 +131,9 @@ const useEditor = () => {
     },
     [setCodeSelection],
   );
+
   const { debouncedAutoSave } = useSaveCommand();
+
   // handleOnChange
   const onChange = useCallback(
     (value: string) => {
@@ -151,6 +155,7 @@ const useEditor = () => {
     },
     [debouncedAutoSave, autoSave],
   );
+
   const debouncedOnChange = useCallback(
     debounce((value) => {
       onChange(value);
@@ -158,10 +163,12 @@ const useEditor = () => {
     }, CodeViewSyncDelay),
     [onChange],
   );
+
   const longDebouncedOnChange = useCallback(
     debounce(onChange, CodeViewSyncDelay_Long),
     [onChange],
   );
+
   const handleOnChange = useCallback(
     (value: string | undefined) => {
       if (value === undefined) return;
@@ -182,6 +189,7 @@ const useEditor = () => {
     action: "none" | "undo" | "redo";
     toggle: boolean;
   }>({ action: "none", toggle: false });
+
   useEffect(() => {
     if (undoRedoToggle.action === "undo") {
       onUndo();

--- a/src/pages/main/hooks/useHandlers.ts
+++ b/src/pages/main/hooks/useHandlers.ts
@@ -67,8 +67,14 @@ export const useHandlers = ({
 }: IUseHandlers) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { osType, navigatorDropdownType, project, fileTree, currentFileUid } =
-    useAppState();
+  const {
+    osType,
+    navigatorDropdownType,
+    project,
+    fileTree,
+    currentFileUid,
+    webComponentOpen,
+  } = useAppState();
 
   const { "*": rest } = useParams();
 
@@ -284,6 +290,7 @@ export const useHandlers = ({
   }, [project, currentProjectFileHandle, osType, fileTree, currentFileUid]);
 
   const closeNavigator = useCallback(() => {
+    if (webComponentOpen) return;
     navigatorDropdownType !== null && dispatch(setNavigatorDropdownType(null));
   }, [navigatorDropdownType]);
 


### PR DESCRIPTION
-  The code panel when the JS file is opened should not interfere (such as scroll) with the HTML node
-  The code panel shouldn't start from the end when opening wc file.
-  The file panel shouldn't be collapsed and the node panel shouldn't expand