### PR TITLE
fixed cursor jumping

### DIFF
--- a/src/components/main/codeView/CodeView.tsx
+++ b/src/components/main/codeView/CodeView.tsx
@@ -68,12 +68,14 @@ export default function CodeView() {
     const fileData = file.data as TFileNodeData;
     const extension = fileData.ext;
     extension && updateLanguage(extension);
+  }, [fileTree, currentFileUid]);
 
-    //scroll to top
+  //scroll to top on file change
+  useEffect(() => {
     const monacoEditor = monacoEditorRef.current;
     if (!monacoEditor) return;
     monacoEditor.setScrollTop(0);
-  }, [fileTree, currentFileUid]);
+  }, [currentFileUid]);
 
   // focusedItem -> code select
   const focusedItemRef = useRef<TNodeUid>("");


### PR DESCRIPTION
Cursor jumping appeared because previously implemented scrolling up when changing a file, but it was also triggered when changing the file tree