### PR TITLE
onChange Bug Fixed!

### DIFF
--- a/src/_node/node/actions.ts
+++ b/src/_node/node/actions.ts
@@ -256,9 +256,6 @@ const copy = async ({
     })();
     dispatch(setNeedToSelectNodePaths(needToSelectNodePaths));
 
-    const code = html_beautify(codeViewInstanceModel.getValue());
-    codeViewInstanceModel.setValue(code);
-
     cb && cb();
   } catch (err) {
     LogAllow && console.error("Error writing to clipboard:", err);


### PR DESCRIPTION
fixed the bug "when we copy a node from stage, it should ideally not change any content. However, it triggers the onChange event on the useEditor."