### PR TITLE
Added error handling

### DIFF
--- a/src/_node/file/handlers/constants.ts
+++ b/src/_node/file/handlers/constants.ts
@@ -1,3 +1,15 @@
 export const StageNodeIdAttr = "data-rnbw-stage-node-id";
 export const PreserveRnbwNode = "data-rnbw-preserve-node";
 export const DataSequencedUid = "data-sequenced-uid";
+
+export const PARSING_ERROR_MESSAGES: Record<string, string> = {
+  "unexpected-solidus-in-tag": "Unexpected symbol in tag",
+  "missing-end-tag-name": "Missing end tag name",
+  "end-tag-with-trailing-solidus": "end-tag-with-trailing-solidus",
+  "missing-attribute-value": "Missing attribute value",
+  "duplicate-attribute": "Duplicate attribute",
+  "invalid-character-sequence-after-doctype-name":
+    "Invalid character sequence after doctype name",
+  "missing-doctype": "Missing doctype",
+  "abrupt-closing-of-empty-comment": "Abrupt closing of empty comment",
+};

--- a/src/_node/file/handlers/handlers.ts
+++ b/src/_node/file/handlers/handlers.ts
@@ -11,7 +11,12 @@ import {
   THtmlNodeTreeData,
   THtmlParserResponse,
 } from "../../node/type/html";
-import { DataSequencedUid, StageNodeIdAttr } from "./constants";
+import {
+  DataSequencedUid,
+  PARSING_ERROR_MESSAGES,
+  StageNodeIdAttr,
+} from "./constants";
+import { toast } from "react-toastify";
 
 const parseHtml = (content: string): THtmlParserResponse => {
   const htmlDom = parse5.parse(content, {
@@ -19,6 +24,10 @@ const parseHtml = (content: string): THtmlParserResponse => {
     sourceCodeLocationInfo: true,
     onParseError: (err) => {
       console.error(err);
+
+      if (PARSING_ERROR_MESSAGES.hasOwnProperty(err.code)) {
+        toast(PARSING_ERROR_MESSAGES[err.code], { type: "error" });
+      }
     },
   });
 


### PR DESCRIPTION
Errors described in [issue 651](https://github.com/rnbwdev/rnbw/issues/651) are handled by a try catch block and let the user know that an error has occurred. 

Sometimes the error handled by onParseError in the parser returns inaccurate errors to the user, for example, if the user starts typing code and the parser updates the code but the code typing has not been finished, the parser may throw an error message that is not true.

Therefore, we can add to the `PARSING_ERROR_MESSAGES` all the errors that we would like to warn users about that can be caught by onParseError, [here are all the possible errors that the parser can return](https://parse5.js.org/enums/parse5.ErrorCodes.html)