### PR TITLE
558 stage - single/multi-level depth navigation

### DIFF
--- a/src/_node/file/handlers/handlers.ts
+++ b/src/_node/file/handlers/handlers.ts
@@ -110,8 +110,10 @@ const parseHtml = (content: string): THtmlParserResponse => {
 
         data: {
           childNodes: node.childNodes,
-          valid: true,
-          // valid: node.nodeName !== "#documentType" && node.nodeName !== "#text",
+          valid:
+            node.nodeName == "#documentType" || node.nodeName == "#text"
+              ? !!node?.value?.replace(/[\n\s]/g, "").length
+              : true,
 
           nodeName: node.nodeName,
           tagName: node.tagName || "",

--- a/src/_node/file/handlers/handlers.ts
+++ b/src/_node/file/handlers/handlers.ts
@@ -110,8 +110,8 @@ const parseHtml = (content: string): THtmlParserResponse => {
 
         data: {
           childNodes: node.childNodes,
-
-          valid: node.nodeName !== "#documentType" && node.nodeName !== "#text",
+          valid: true,
+          // valid: node.nodeName !== "#documentType" && node.nodeName !== "#text",
 
           nodeName: node.nodeName,
           tagName: node.tagName || "",

--- a/src/_node/node/helpers.ts
+++ b/src/_node/node/helpers.ts
@@ -92,7 +92,8 @@ export const replaceContent = ({
   codeViewInstanceModel: editor.ITextModel;
 }) => {
   const focusedNode = nodeTree[focusedItem];
-  const { startTag, endTag } = focusedNode.data.sourceCodeLocation;
+  const { startTag, endTag, startLine, endLine, startCol, endCol } =
+    focusedNode.data.sourceCodeLocation;
   if (startTag && endTag) {
     const edit = {
       range: new Range(
@@ -101,6 +102,12 @@ export const replaceContent = ({
         endTag.startLine,
         endTag.startCol,
       ),
+      text: content,
+    };
+    codeViewInstanceModel.applyEdits([edit]);
+  } else if (startLine && endLine && startCol && endCol) {
+    const edit = {
+      range: new Range(startLine, startCol, endLine, endCol),
       text: content,
     };
     codeViewInstanceModel.applyEdits([edit]);

--- a/src/_redux/main/nodeTree/event/slice.ts
+++ b/src/_redux/main/nodeTree/event/slice.ts
@@ -26,11 +26,13 @@ const nodeEventSlice = createSlice({
     },
     setSelectedNodeUids(state, action: PayloadAction<TNodeUid[]>) {
       const selectedNodeUids = action.payload;
-      if (
-        !selectedNodeUids.every((item) => state.selectedNodeUids.includes(item))
-      ) {
-        state.selectedNodeUids = [...selectedNodeUids];
-      }
+
+      // if (
+      //   !selectedNodeUids.every((item) => state.selectedNodeUids.includes(item))
+      // ) {
+
+      state.selectedNodeUids = [...selectedNodeUids];
+      // }
     },
     setNeedToSelectNodeUids(state, action: PayloadAction<TNodeUid[]>) {
       const needToSelectNodeUids = action.payload;

--- a/src/components/main/actionsPanel/nodeTreeView/NodeTreeView.tsx
+++ b/src/components/main/actionsPanel/nodeTreeView/NodeTreeView.tsx
@@ -15,7 +15,6 @@ import { useDispatch } from "react-redux";
 import { TreeView } from "@_components/common";
 import { TreeViewData } from "@_components/common/treeView/types";
 import { DargItemImage, RootNodeUid } from "@_constants/main";
-import { StageNodeIdAttr } from "@_node/file/handlers/constants";
 import { THtmlNodeData } from "@_node/index";
 import { TNode, TNodeUid } from "@_node/types";
 import {
@@ -254,26 +253,18 @@ const NodeTreeView = () => {
               [props.item],
             );
 
-            const onMouseEnter = useCallback((e: React.MouseEvent) => {
-              const ele = e.target as HTMLElement;
-              let _uid: TNodeUid | null = ele.getAttribute("id");
-              // for the elements which are created by js. (ex: Web Component)
-              let newHoveredElement: HTMLElement = ele;
+            const onMouseEnter = () => {
+              let _uid = props?.item?.data?.uid;
               if (_uid === null || _uid === undefined) return;
-              _uid = _uid?.substring(13, _uid.length);
+              let node = validNodeTree[_uid];
               while (!_uid) {
-                const parentEle = newHoveredElement.parentElement;
-                if (!parentEle) break;
-
-                _uid = parentEle.getAttribute(StageNodeIdAttr);
-                !_uid ? (newHoveredElement = parentEle) : null;
+                _uid = node.parentUid;
+                !_uid ? (node = validNodeTree[_uid]) : null;
               }
-
-              // set hovered item
               if (_uid && _uid !== hoveredNodeUid) {
                 dispatch(setHoveredNodeUid(_uid));
               }
-            }, []);
+            };
 
             const onMouseLeave = useCallback(() => {
               dispatch(setHoveredNodeUid(""));

--- a/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeViewState.ts
+++ b/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeViewState.ts
@@ -47,8 +47,6 @@ export function useNodeViewState() {
           return;
         }
       }
-      console.log(_uids, "_uids");
-
       dispatch(setSelectedNodeUids(_uids));
 
       // update file - WIP

--- a/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeViewState.ts
+++ b/src/components/main/actionsPanel/nodeTreeView/hooks/useNodeViewState.ts
@@ -47,6 +47,7 @@ export function useNodeViewState() {
           return;
         }
       }
+      console.log(_uids, "_uids");
 
       dispatch(setSelectedNodeUids(_uids));
 

--- a/src/components/main/stageView/iFrame/IFrame.tsx
+++ b/src/components/main/stageView/iFrame/IFrame.tsx
@@ -20,7 +20,7 @@ import { useZoom } from "./hooks/useZoom";
 
 export const IFrame = () => {
   const dispatch = useDispatch();
-  const { needToReloadIframe, iframeSrc, project } = useAppState();
+  const { needToReloadIframe, iframeSrc, project, nodeTree } = useAppState();
   const { iframeRefRef, setIframeRefRef } = useContext(MainContext);
 
   const [iframeRefState, setIframeRefState] =
@@ -108,7 +108,11 @@ export const IFrame = () => {
         }
 
         // mark selected elements on load
-        markSelectedElements(iframeRefState, selectedItemsRef.current);
+        markSelectedElements(
+          iframeRefState,
+          selectedItemsRef.current,
+          nodeTree,
+        );
 
         dispatch(setIframeLoading(false));
         project.context === "local" && dispatch(setLoadingFalse());

--- a/src/components/main/stageView/iFrame/IFrame.tsx
+++ b/src/components/main/stageView/iFrame/IFrame.tsx
@@ -49,6 +49,7 @@ export const IFrame = () => {
     contentEditableUidRef,
     isEditingRef,
     hoveredItemRef,
+    selectedItemsRef,
   });
   const { onMouseEnter, onMouseMove, onMouseLeave, onClick, onDblClick } =
     useMouseEvents({

--- a/src/components/main/stageView/iFrame/IFrame.tsx
+++ b/src/components/main/stageView/iFrame/IFrame.tsx
@@ -31,26 +31,24 @@ export const IFrame = () => {
 
   const contentEditableUidRef = useRef<TNodeUid>("");
   const isEditingRef = useRef(false);
-  const linkTagUidRef = useRef<TNodeUid>("");
 
   // hooks
-  const { nodeTreeRef, focusedItemRef, selectedItemsRef } =
+  const { nodeTreeRef, hoveredItemRef, selectedItemsRef } =
     useSyncNode(iframeRefState);
-  const { onKeyDown } = useCmdk({
+  const { onKeyDown, onKeyUp } = useCmdk({
     iframeRefRef,
     nodeTreeRef,
     contentEditableUidRef,
     isEditingRef,
+    hoveredItemRef,
   });
   const { onMouseEnter, onMouseMove, onMouseLeave, onClick, onDblClick } =
     useMouseEvents({
       iframeRefRef,
       nodeTreeRef,
-      focusedItemRef,
       selectedItemsRef,
       contentEditableUidRef,
       isEditingRef,
-      linkTagUidRef,
     });
 
   // init iframe
@@ -103,7 +101,10 @@ export const IFrame = () => {
             e.preventDefault();
             onDblClick(e);
           });
-
+          htmlNode.addEventListener("keyup", (e: KeyboardEvent) => {
+            e.preventDefault();
+            onKeyUp(e);
+          });
           // disable contextmenu
           _document.addEventListener("contextmenu", (e: MouseEvent) => {
             e.preventDefault();

--- a/src/components/main/stageView/iFrame/constants/styles.ts
+++ b/src/components/main/stageView/iFrame/constants/styles.ts
@@ -10,19 +10,19 @@ html {
 }
 
 /* Common style for hover state on non-text elements */
-[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(p) {
+[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]):not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(p) {
   outline: 2px solid var(--color-rnbwdev-rainbow-element-foreground);
   outline-offset: -1px;
 }
 
 /* Specific style for text-type elements when hovered and not selected */
-h1[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]),
-h2[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]),
-h3[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]),
-h4[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]),
-h5[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]),
-h6[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]),
-p[rnbwdev-rnbw-element-hover]:hover:not([rnbwdev-rnbw-element-select]) {
+h1[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]),
+h2[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]),
+h3[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]),
+h4[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]),
+h5[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]),
+h6[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]),
+p[rnbwdev-rnbw-element-hover]:not([rnbwdev-rnbw-element-select]) {
   text-decoration: underline;
   text-decoration-color: var(--color-rnbwdev-rainbow-element-foreground);
   text-decoration-thickness: 2px; /* Increased to 2px when hovered and not selected */

--- a/src/components/main/stageView/iFrame/helpers.ts
+++ b/src/components/main/stageView/iFrame/helpers.ts
@@ -204,3 +204,36 @@ export const isChildrenHasWebComponents = ({
 
   return false;
 };
+export const areArraysEqual = (arr1: string[], arr2: string[]) => {
+  let same = false;
+  if (arr1.length === arr2.length) {
+    same = true;
+    for (let index = 0, len = arr1.length; index < len; ++index) {
+      if (arr1[index] !== arr2[index]) {
+        same = false;
+        break;
+      }
+    }
+  }
+  return same;
+};
+export const getBodyChild = ({
+  uids,
+  nodeTree,
+}: {
+  uids: TNodeUid[];
+  nodeTree: TNodeTreeData;
+}) => {
+  const bodyChildren = uids.map((currentUid) => {
+    let current: string = currentUid;
+    let parentUid = nodeTree[currentUid]?.parentUid;
+
+    while (parentUid && nodeTree[parentUid]?.displayName !== "body") {
+      current = parentUid;
+      parentUid = nodeTree[parentUid]?.parentUid;
+    }
+
+    return current;
+  });
+  return bodyChildren;
+};

--- a/src/components/main/stageView/iFrame/helpers.ts
+++ b/src/components/main/stageView/iFrame/helpers.ts
@@ -270,7 +270,7 @@ export const isSameParents = ({
 
   while (parentUid && parentUid !== nodeTree[selectedUid].parentUid) {
     current = parentUid;
-    parentUid = nodeTree[parentUid]?.parentUid;
+    parentUid = nodeTree?.[parentUid]?.parentUid;
   }
   return parentUid == nodeTree[selectedUid]?.parentUid ? current : false;
 };

--- a/src/components/main/stageView/iFrame/helpers.ts
+++ b/src/components/main/stageView/iFrame/helpers.ts
@@ -27,24 +27,36 @@ export const getValidElementWithUid = (
 export const markSelectedElements = (
   iframeRef: HTMLIFrameElement | null,
   uids: TNodeUid[],
+  nodeTree: TNodeTreeData,
 ) => {
   uids.map((uid) => {
     // if it's a web component, should select its first child element
     let selectedElement = iframeRef?.contentWindow?.document?.querySelector(
       `[${StageNodeIdAttr}="${uid}"]`,
     );
+    console.log(selectedElement, "selectedElement");
+
     const isValid: null | string = selectedElement?.firstElementChild
       ? selectedElement?.firstElementChild.getAttribute(StageNodeIdAttr)
       : "";
+
     isValid === null
       ? (selectedElement = selectedElement?.firstElementChild)
       : null;
     selectedElement?.setAttribute("rnbwdev-rnbw-element-select", "");
+
+    if (!selectedElement && nodeTree[uid]?.displayName === "#text") {
+      const selectedElement = iframeRef?.contentWindow?.document?.querySelector(
+        `[${StageNodeIdAttr}="${nodeTree[uid].parentUid}"]`,
+      );
+      selectedElement?.setAttribute("rnbwdev-rnbw-element-select", "");
+    }
   });
 };
 export const unmarkSelectedElements = (
   iframeRef: HTMLIFrameElement | null,
   uids: TNodeUid[],
+  nodeTree: TNodeTreeData,
 ) => {
   uids.map((uid) => {
     // if it's a web component, should select its first child element
@@ -58,6 +70,13 @@ export const unmarkSelectedElements = (
       ? (selectedElement = selectedElement?.firstElementChild)
       : null;
     selectedElement?.removeAttribute("rnbwdev-rnbw-element-select");
+
+    if (!selectedElement && nodeTree[uid]?.displayName === "#text") {
+      const selectedElement = iframeRef?.contentWindow?.document?.querySelector(
+        `[${StageNodeIdAttr}="${nodeTree[uid].parentUid}"]`,
+      );
+      selectedElement?.removeAttribute("rnbwdev-rnbw-element-select");
+    }
   });
 };
 

--- a/src/components/main/stageView/iFrame/helpers.ts
+++ b/src/components/main/stageView/iFrame/helpers.ts
@@ -272,6 +272,5 @@ export const isSameParents = ({
     current = parentUid;
     parentUid = nodeTree[parentUid]?.parentUid;
   }
-
-  return parentUid == nodeTree[selectedUid].parentUid ? current : false;
+  return parentUid == nodeTree[selectedUid]?.parentUid ? current : false;
 };

--- a/src/components/main/stageView/iFrame/helpers.ts
+++ b/src/components/main/stageView/iFrame/helpers.ts
@@ -34,7 +34,6 @@ export const markSelectedElements = (
     let selectedElement = iframeRef?.contentWindow?.document?.querySelector(
       `[${StageNodeIdAttr}="${uid}"]`,
     );
-    console.log(selectedElement, "selectedElement");
 
     const isValid: null | string = selectedElement?.firstElementChild
       ? selectedElement?.firstElementChild.getAttribute(StageNodeIdAttr)
@@ -236,4 +235,43 @@ export const getBodyChild = ({
     return current;
   });
   return bodyChildren;
+};
+
+export const getChild = ({
+  currentUid,
+  nodeTree,
+  selectedUid,
+}: {
+  currentUid: TNodeUid;
+  nodeTree: TNodeTreeData;
+  selectedUid: TNodeUid;
+}) => {
+  let current: string = currentUid;
+  let parentUid = nodeTree[currentUid]?.parentUid;
+
+  while (parentUid && parentUid !== selectedUid) {
+    current = parentUid;
+    parentUid = nodeTree[parentUid]?.parentUid;
+  }
+
+  return current;
+};
+export const isSameParents = ({
+  currentUid,
+  nodeTree,
+  selectedUid,
+}: {
+  currentUid: TNodeUid;
+  nodeTree: TNodeTreeData;
+  selectedUid: TNodeUid;
+}) => {
+  let current: string = currentUid;
+  let parentUid = nodeTree[currentUid]?.parentUid;
+
+  while (parentUid && parentUid !== nodeTree[selectedUid].parentUid) {
+    current = parentUid;
+    parentUid = nodeTree[parentUid]?.parentUid;
+  }
+
+  return parentUid == nodeTree[selectedUid].parentUid ? current : false;
 };

--- a/src/components/main/stageView/iFrame/helpers.ts
+++ b/src/components/main/stageView/iFrame/helpers.ts
@@ -208,17 +208,17 @@ export const getBodyChild = ({
       current = parentUid;
       parentUid = nodeTree[parentUid]?.parentUid;
     }
-    const rootIndex = nodeTree[current].children.findIndex(
-      (uid) => nodeTree[uid].displayName === "html",
+    const rootIndex = nodeTree[current]?.children?.findIndex(
+      (uid) => nodeTree[uid]?.displayName === "html",
     );
 
     if (rootIndex !== -1) {
-      const htmlNode = nodeTree[nodeTree[current].children[rootIndex]];
-      const bodyIndex = htmlNode.children.findIndex(
-        (uid) => nodeTree[uid].displayName === "body",
+      const htmlNode = nodeTree[nodeTree[current]?.children[rootIndex]];
+      const bodyIndex = htmlNode?.children?.findIndex(
+        (uid) => nodeTree[uid]?.displayName === "body",
       );
       if (bodyIndex !== -1) {
-        current = htmlNode.children[bodyIndex];
+        current = htmlNode?.children[bodyIndex];
       }
     }
 

--- a/src/components/main/stageView/iFrame/hooks/useCmdk.ts
+++ b/src/components/main/stageView/iFrame/hooks/useCmdk.ts
@@ -20,6 +20,7 @@ interface IUseCmdkProps {
   contentEditableUidRef: React.MutableRefObject<TNodeUid>;
   isEditingRef: React.MutableRefObject<boolean>;
   hoveredItemRef: React.MutableRefObject<TNodeUid>;
+  selectedItemsRef: React.MutableRefObject<TNodeUid[]>;
 }
 
 export const useCmdk = ({
@@ -28,6 +29,7 @@ export const useCmdk = ({
   contentEditableUidRef,
   isEditingRef,
   hoveredItemRef,
+  selectedItemsRef,
 }: IUseCmdkProps) => {
   const dispatch = useDispatch();
   const { osType, cmdkReferenceData } = useAppState();
@@ -141,7 +143,11 @@ export const useCmdk = ({
 
   const onKeyUp = useCallback(
     (e: KeyboardEvent) => {
-      if (!hoveredItemRef.current) return;
+      if (
+        !hoveredItemRef.current ||
+        selectedItemsRef.current.includes(hoveredItemRef.current)
+      )
+        return;
 
       if (
         ((osType === "Windows" || osType === "Linux") && e.key == "Control") ||

--- a/src/components/main/stageView/iFrame/hooks/useCmdk.ts
+++ b/src/components/main/stageView/iFrame/hooks/useCmdk.ts
@@ -10,14 +10,16 @@ import { useAppState } from "@_redux/useAppState";
 import { getCommandKey } from "@_services/global";
 import { TCmdkKeyMap } from "@_types/main";
 
-import { editHtmlContent } from "../helpers";
+import { editHtmlContent, getBodyChild } from "../helpers";
 import { setShowActionsPanel, setShowCodeView } from "@_redux/main/processor";
+import { setHoveredNodeUid } from "@_redux/main/nodeTree";
 
 interface IUseCmdkProps {
   iframeRefRef: React.MutableRefObject<HTMLIFrameElement | null>;
   nodeTreeRef: React.MutableRefObject<TNodeTreeData>;
   contentEditableUidRef: React.MutableRefObject<TNodeUid>;
   isEditingRef: React.MutableRefObject<boolean>;
+  hoveredItemRef: React.MutableRefObject<TNodeUid>;
 }
 
 export const useCmdk = ({
@@ -25,6 +27,7 @@ export const useCmdk = ({
   nodeTreeRef,
   contentEditableUidRef,
   isEditingRef,
+  hoveredItemRef,
 }: IUseCmdkProps) => {
   const dispatch = useDispatch();
   const { osType, cmdkReferenceData } = useAppState();
@@ -131,5 +134,23 @@ export const useCmdk = ({
     [osType, cmdkReferenceData],
   );
 
-  return { onKeyDown };
+  const onKeyUp = useCallback(
+    (e: KeyboardEvent) => {
+      if (!hoveredItemRef.current) return;
+
+      if (
+        ((osType === "Windows" || osType === "Linux") && e.key == "Control") ||
+        (osType === "Mac" && e.key == "Meta")
+      ) {
+        const targetUid = getBodyChild({
+          uids: [hoveredItemRef.current],
+          nodeTree: nodeTreeRef.current,
+        });
+
+        dispatch(setHoveredNodeUid(targetUid[0]));
+      }
+    },
+    [osType],
+  );
+  return { onKeyDown, onKeyUp };
 };

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -64,11 +64,7 @@ export const useMouseEvents = ({
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
       if (!uid) return;
       if (e.ctrlKey || e.metaKey) {
-        const currentUid =
-          validNodeTree[uid]?.displayName == "#text"
-            ? validNodeTree[uid]?.parentUid || uid
-            : uid;
-        currentUid && dispatch(setHoveredNodeUid(currentUid));
+        dispatch(setHoveredNodeUid(uid));
       } else {
         const isSelectedChild = isChild({
           currentUid: uid,
@@ -112,11 +108,7 @@ export const useMouseEvents = ({
 
         let targetUids = uids;
         if (e.ctrlKey || e.metaKey) {
-          targetUids = uids.map((uid) =>
-            validNodeTree[uid]?.displayName == "#text"
-              ? validNodeTree[uid]?.parentUid || uid
-              : uid,
-          );
+          targetUids = uids;
         } else {
           const sameParents = isSameParents({
             currentUid: uid,

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -68,6 +68,7 @@ export const useMouseEvents = ({
   // click, dblclick handlers
   const onClick = useCallback((e: MouseEvent) => {
     dispatch(setActivePanel("stage"));
+    console.log(e.target, "e.target");
 
     const { uid } = getValidElementWithUid(e.target as HTMLElement);
     if (uid) {
@@ -170,6 +171,12 @@ export const useMouseEvents = ({
         console.log("nodeData", mostRecentClickedNodeUidRef.current);
 
         if (["html", "head", "body", "img", "div"].includes(nodeData.nodeName))
+          return;
+        if (
+          !nodeTree[uid].children.some(
+            (childUId) => validNodeTree[childUId]?.displayName === "#text",
+          )
+        )
           return;
         if (isChildrenHasWebComponents({ nodeTree, uid })) return;
 

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -61,12 +61,26 @@ export const useMouseEvents = ({
 
   // hoveredNodeUid
   const onMouseEnter = useCallback(() => {}, []);
-  const onMouseMove = useCallback((e: MouseEvent) => {
-    if (e.ctrlKey || e.metaKey) {
+  const onMouseMove = useCallback(
+    (e: MouseEvent) => {
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
-      uid && dispatch(setHoveredNodeUid(uid));
-    }
-  }, []);
+      if (!uid) return;
+      if (e.ctrlKey || e.metaKey) {
+        uid && dispatch(setHoveredNodeUid(uid));
+      } else {
+        const sameParents = isSameParents({
+          currentUid: uid,
+          nodeTree,
+          selectedUid: selectedItemsRef.current[0],
+        });
+        const targetUids = sameParents
+          ? [sameParents]
+          : getBodyChild({ uids: [uid], nodeTree });
+        dispatch(setHoveredNodeUid(targetUids[0]));
+      }
+    },
+    [nodeTree],
+  );
   const onMouseLeave = () => {
     dispatch(setHoveredNodeUid(""));
   };

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -66,20 +66,24 @@ export const useMouseEvents = ({
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
       if (!uid) return;
       if (e.ctrlKey || e.metaKey) {
-        uid && dispatch(setHoveredNodeUid(uid));
+        const currentUid =
+          validNodeTree[uid]?.displayName == "#text"
+            ? validNodeTree[uid]?.parentUid || uid
+            : uid;
+        currentUid && dispatch(setHoveredNodeUid(currentUid));
       } else {
         const sameParents = isSameParents({
           currentUid: uid,
-          nodeTree,
+          nodeTree: nodeTreeRef.current,
           selectedUid: selectedItemsRef.current[0],
         });
         const targetUids = sameParents
           ? [sameParents]
-          : getBodyChild({ uids: [uid], nodeTree });
+          : getBodyChild({ uids: [uid], nodeTree: nodeTreeRef.current });
         dispatch(setHoveredNodeUid(targetUids[0]));
       }
     },
-    [nodeTree],
+    [validNodeTree],
   );
   const onMouseLeave = () => {
     dispatch(setHoveredNodeUid(""));
@@ -109,18 +113,22 @@ export const useMouseEvents = ({
 
         let targetUids = uids;
         if (e.ctrlKey || e.metaKey) {
-          targetUids = uids;
+          targetUids = uids.map((uid) =>
+            validNodeTree[uid]?.displayName == "#text"
+              ? validNodeTree[uid]?.parentUid || uid
+              : uid,
+          );
         } else {
           // need to understand if uid has same parents with selectedUId
           const sameParents = isSameParents({
             currentUid: uid,
-            nodeTree: validNodeTree,
+            nodeTree: nodeTreeRef.current,
             selectedUid: selectedItemsRef.current[0],
           });
 
           targetUids = sameParents
             ? [sameParents]
-            : getBodyChild({ uids, nodeTree: validNodeTree });
+            : getBodyChild({ uids, nodeTree: nodeTreeRef.current });
         }
 
         // check if it's a new state
@@ -199,7 +207,7 @@ export const useMouseEvents = ({
 
         const targetUid = getChild({
           currentUid: dbClickedUid,
-          nodeTree: validNodeTree,
+          nodeTree: nodeTreeRef.current,
           selectedUid: selectedItemsRef.current[0],
         });
 
@@ -243,6 +251,7 @@ export const useMouseEvents = ({
       validNodeTree,
       mostRecentClickedNodeUidRef.current,
       nodeTree,
+      selectedItemsRef,
     ],
   );
 

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -27,15 +27,14 @@ import {
   onWebComponentDblClick,
 } from "@_pages/main/helper";
 import { useAppState } from "@_redux/useAppState";
+import { getCommandKey } from "@_services/global";
 
 interface IUseMouseEventsProps {
   iframeRefRef: React.MutableRefObject<HTMLIFrameElement | null>;
   nodeTreeRef: React.MutableRefObject<TNodeTreeData>;
-  focusedItemRef: React.MutableRefObject<TNodeUid>;
   selectedItemsRef: React.MutableRefObject<TNodeUid[]>;
   contentEditableUidRef: React.MutableRefObject<TNodeUid>;
   isEditingRef: React.MutableRefObject<boolean>;
-  linkTagUidRef: React.MutableRefObject<TNodeUid>;
 }
 
 export const useMouseEvents = ({
@@ -53,6 +52,7 @@ export const useMouseEvents = ({
     fExpandedItemsObj: expandedItemsObj,
     formatCode,
     htmlReferenceData,
+    osType,
   } = useAppState();
 
   const mostRecentClickedNodeUidRef = useRef<TNodeUid>(""); //This is used because dbl clikc event was not able to receive the uid of the node that was clicked
@@ -63,8 +63,9 @@ export const useMouseEvents = ({
     (e: MouseEvent) => {
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
       if (!uid) return;
-      if (e.ctrlKey || e.metaKey) {
+      if (getCommandKey(e, osType)) {
         dispatch(setHoveredNodeUid(uid));
+        iframeRefRef.current?.focus();
       } else {
         const isSelectedChild = isChild({
           currentUid: uid,
@@ -80,7 +81,7 @@ export const useMouseEvents = ({
         dispatch(setHoveredNodeUid(targetUids[0]));
       }
     },
-    [validNodeTree],
+    [validNodeTree, osType],
   );
   const onMouseLeave = () => {
     dispatch(setHoveredNodeUid(""));
@@ -107,7 +108,7 @@ export const useMouseEvents = ({
           : [uid];
 
         let targetUids = uids;
-        if (e.ctrlKey || e.metaKey) {
+        if (getCommandKey(e, osType)) {
           targetUids = uids;
         } else {
           const sameParents = isSameParents({
@@ -156,7 +157,7 @@ export const useMouseEvents = ({
         });
       }
     },
-    [validNodeTree, nodeTreeRef, selectedItemsRef],
+    [validNodeTree, nodeTreeRef, selectedItemsRef, osType],
   );
 
   const debouncedSelectAllText = useCallback(

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -2,7 +2,7 @@ import { useCallback, useContext, useRef } from "react";
 import { useDispatch } from "react-redux";
 
 import { LogAllow } from "@_constants/global";
-import { ShortDelay } from "@_constants/main";
+import { RootNodeUid, ShortDelay } from "@_constants/main";
 import { StageNodeIdAttr } from "@_node/file";
 import { getValidNodeUids } from "@_node/helpers";
 import { THtmlNodeData } from "@_node/node";
@@ -16,8 +16,10 @@ import {
   areArraysEqual,
   editHtmlContent,
   getBodyChild,
+  getChild,
   getValidElementWithUid,
   isChildrenHasWebComponents,
+  isSameParents,
   selectAllText,
 } from "../helpers";
 import {
@@ -79,10 +81,13 @@ export const useMouseEvents = ({
         mostRecentClickedNodeUidRef.current = uid;
         // update selectedNodeUids
         (() => {
+          const updatedSelectedItems = selectedItemsRef.current.includes(uid)
+            ? selectedItemsRef.current.filter((item) => item !== uid)
+            : [...selectedItemsRef.current, uid];
           const uids = e.shiftKey
             ? getValidNodeUids(
                 nodeTreeRef.current,
-                Array(...new Set([...selectedItemsRef.current, uid])),
+                Array(...new Set(updatedSelectedItems)),
               )
             : [uid];
 
@@ -90,7 +95,15 @@ export const useMouseEvents = ({
           if (e.ctrlKey || e.metaKey) {
             targetUids = uids;
           } else {
-            targetUids = getBodyChild({ uids, nodeTree });
+            // need to understand if uid has same parents with selectedUId
+            const sameParents = isSameParents({
+              currentUid: uid,
+              nodeTree,
+              selectedUid: selectedItemsRef.current[0],
+            });
+            targetUids = sameParents
+              ? [sameParents]
+              : getBodyChild({ uids, nodeTree });
           }
 
           // check if it's a new state
@@ -129,7 +142,7 @@ export const useMouseEvents = ({
         }
       }
     },
-    [nodeTree],
+    [nodeTree, selectedItemsRef],
   );
 
   const debouncedSelectAllText = useCallback(
@@ -141,6 +154,9 @@ export const useMouseEvents = ({
       const ele = e.target as HTMLElement;
       const uid: TNodeUid | null = ele.getAttribute(StageNodeIdAttr);
 
+      const { uid: dbClickedUd } = getValidElementWithUid(
+        e.target as HTMLElement,
+      );
       if (!uid) {
         // when dbl-click on a web component
         isEditingRef.current = false;
@@ -165,24 +181,41 @@ export const useMouseEvents = ({
           }
         }
       } else {
-        const node = nodeTreeRef.current[uid];
-        const nodeData = node.data as THtmlNodeData;
-        console.log("nodeData", mostRecentClickedNodeUidRef.current);
+        if (!dbClickedUd) return;
+        const targetUid = getChild({
+          currentUid: dbClickedUd,
+          nodeTree,
+          selectedUid: selectedItemsRef.current[0],
+        });
+        const same = areArraysEqual(selectedItemsRef.current, [targetUid]);
+        !same &&
+          dispatch(
+            setSelectedNodeUids([
+              targetUid !== RootNodeUid ? targetUid : dbClickedUd,
+            ]),
+          );
 
-        if (["html", "head", "body", "img", "div"].includes(nodeData.nodeName))
-          return;
+        if (targetUid !== RootNodeUid) return;
+        const node = nodeTreeRef.current[dbClickedUd];
+        const nodeData = node.data as THtmlNodeData;
+
+        if (["html", "head", "body", "img"].includes(nodeData.nodeName)) return;
         if (
-          !nodeTree[uid].children.some(
+          !nodeTree[dbClickedUd].children.some(
             (childUId) => validNodeTree[childUId]?.displayName === "#text",
           )
         )
           return;
-        if (isChildrenHasWebComponents({ nodeTree, uid })) return;
+        if (isChildrenHasWebComponents({ nodeTree, uid: dbClickedUd })) return;
 
         const { startTag, endTag } = nodeData.sourceCodeLocation;
-        if (startTag && endTag && contentEditableUidRef.current !== uid) {
+        if (
+          startTag &&
+          endTag &&
+          contentEditableUidRef.current !== dbClickedUd
+        ) {
           isEditingRef.current = true;
-          contentEditableUidRef.current = uid;
+          contentEditableUidRef.current = dbClickedUd;
           ele.setAttribute("contenteditable", "true");
           ele.focus();
           debouncedSelectAllText(iframeRefRef.current, ele);

--- a/src/components/main/stageView/iFrame/hooks/useSyncNode.ts
+++ b/src/components/main/stageView/iFrame/hooks/useSyncNode.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
 
-
 import { ShortDelay } from "@_constants/main";
 import { StageNodeIdAttr } from "@_node/file/handlers/constants";
 import { TNodeTreeData, TNodeUid } from "@_node/types";
@@ -74,8 +73,8 @@ export const useSyncNode = (iframeRef: HTMLIFrameElement | null) => {
       if (same) return;
     }
 
-    unmarkSelectedElements(iframeRef, selectedItemsRef.current);
-    markSelectedElements(iframeRef, selectedItems);
+    unmarkSelectedElements(iframeRef, selectedItemsRef.current, nodeTree);
+    markSelectedElements(iframeRef, selectedItems, nodeTree);
     selectedItemsRef.current = [...selectedItems];
   }, [selectedItems]);
 

--- a/src/pages/main/processor/helpers.ts
+++ b/src/pages/main/processor/helpers.ts
@@ -59,11 +59,14 @@ export const getNodeUidToBeSelectedAtFirst = (validNodeTree: TNodeTreeData) => {
       break;
     }
   }
+  const firstBodyNode = bodyNode?.children.find(
+    (item) => validNodeTree[item].displayName !== "#text",
+  );
 
   return bodyNode === null
     ? uids[0]
     : bodyNode.children.length > 0
-      ? bodyNode.children[0]
+      ? firstBodyNode || bodyNode.children[0]
       : bodyNode.uid;
 };
 export const getNeedToExpandNodeUids = (

--- a/src/pages/main/processor/hooks/useNodeTreeEvent.ts
+++ b/src/pages/main/processor/hooks/useNodeTreeEvent.ts
@@ -271,7 +271,7 @@ export const useNodeTreeEvent = () => {
         ),
       );
     } else {
-      markSelectedElements(iframeRefRef.current, [nFocusedItem]);
+      markSelectedElements(iframeRefRef.current, [nFocusedItem], nodeTree);
       const validExpandedItems = nExpandedItems.filter(
         (uid) => _validNodeTree[uid] && _validNodeTree[uid].isEntity === false,
       );
@@ -316,7 +316,7 @@ export const useNodeTreeEvent = () => {
         // remark selected elements on stage-view
         // it is removed through dom-diff
         // this part is for when the selectedNodeUids is not changed cuz of the same code-format
-        markSelectedElements(iframeRefRef.current, _selectedNodeUids);
+        markSelectedElements(iframeRefRef.current, _selectedNodeUids, nodeTree);
       }
     }
 


### PR DESCRIPTION
Enabled showing text node
Only text-nodes are content-editable
Added navigation down through container elements using Double-click
Selecting elements in all levels by holding the cmd key and clicking on them.
Multiple multi-level selections, hold the shift and command keys while double-clicking on the elements.
