### PR TITLE
Validated state update

### DIFF
--- a/src/components/main/actionsPanel/nodeTreeView/NodeTreeView.tsx
+++ b/src/components/main/actionsPanel/nodeTreeView/NodeTreeView.tsx
@@ -268,7 +268,7 @@ const NodeTreeView = () => {
             };
 
             const onMouseLeave = useCallback(() => {
-              dispatch(setHoveredNodeUid(""));
+              if (hoveredNodeUid !== "") dispatch(setHoveredNodeUid(""));
             }, []);
 
             const onDragStart = (e: React.DragEvent) => {

--- a/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
+++ b/src/components/main/actionsPanel/workspaceTreeView/WorkspaceTreeView.tsx
@@ -71,6 +71,7 @@ export default function WorkspaceTreeView() {
     recentProjectHandlers,
     recentProjectContexts,
     invalidFileNodes,
+    webComponentOpen,
   } = useAppState();
   const { addRunningActions, removeRunningActions, importProject } =
     useContext(MainContext);
@@ -150,7 +151,7 @@ export default function WorkspaceTreeView() {
   useEffect(
     function RevertWcOpen() {
       if (activePanel !== "code") {
-        dispatch(setWebComponentOpen(false));
+        if (webComponentOpen) dispatch(setWebComponentOpen(false));
         openFile(prevRenderableFileUid);
       }
     },

--- a/src/components/main/stageView/iFrame/IFrame.tsx
+++ b/src/components/main/stageView/iFrame/IFrame.tsx
@@ -1,10 +1,17 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { useDispatch } from "react-redux";
 
 import { LogAllow } from "@_constants/global";
 import { PreserveRnbwNode } from "@_node/file/handlers/constants";
-import { TNodeUid } from "@_node/types";
+import { TNodeTreeData, TNodeUid } from "@_node/types";
 import { MainContext } from "@_redux/main";
 import {
   setIframeLoading,
@@ -16,8 +23,33 @@ import { jss, styles } from "./constants";
 import { markSelectedElements } from "./helpers";
 import { useCmdk, useMouseEvents, useSyncNode } from "./hooks";
 import { setLoadingFalse, setLoadingTrue } from "@_redux/main/processor";
+import { TCmdkReferenceData } from "@_redux/main/cmdk";
+import { TOsType } from "@_redux/global";
 
+export interface eventListenersStatesRefType {
+  showCodeView: boolean;
+  showActionsPanel: boolean;
+  needToReloadIframe: boolean;
+  iframeSrc: string | null;
+  iframeRefState: HTMLIFrameElement | null;
+  iframeRefRef: React.MutableRefObject<HTMLIFrameElement | null>;
+  nodeTreeRef: React.MutableRefObject<TNodeTreeData>;
+  contentEditableUidRef: React.MutableRefObject<TNodeUid>;
+  isEditingRef: React.MutableRefObject<boolean>;
+  hoveredItemRef: React.MutableRefObject<TNodeUid>;
+  selectedItemsRef: React.MutableRefObject<TNodeUid[]>;
+  activePanel: string;
+  osType: TOsType;
+  cmdkReferenceData: TCmdkReferenceData;
+  isCodeTyping: boolean;
+  formatCode: boolean;
+}
 export const IFrame = () => {
+  const [iframeRefState, setIframeRefState] =
+    useState<HTMLIFrameElement | null>(null);
+  const [document, setDocument] = useState<Document | string | undefined>("");
+  const contentEditableUidRef = useRef<TNodeUid>("");
+  const isEditingRef = useRef(false);
   const dispatch = useDispatch();
   const {
     needToReloadIframe,
@@ -27,22 +59,23 @@ export const IFrame = () => {
     showCodeView,
     nodeTree,
     validNodeTree,
+    activePanel,
+    osType,
+    cmdkReferenceData,
+    isCodeTyping,
+    formatCode,
   } = useAppState();
   const { iframeRefRef, setIframeRefRef } = useContext(MainContext);
   const allPanelsClosedRef = useRef(!showActionsPanel && !showCodeView);
-
-  const [iframeRefState, setIframeRefState] =
-    useState<HTMLIFrameElement | null>(null);
-
-  const [document, setDocument] = useState<Document | string | undefined>("");
-
-  const contentEditableUidRef = useRef<TNodeUid>("");
-  const isEditingRef = useRef(false);
-
   // hooks
   const { nodeTreeRef, hoveredItemRef, selectedItemsRef } =
     useSyncNode(iframeRefState);
-  const { onKeyDown, onKeyUp } = useCmdk({
+
+  const eventListenersStatesRef = useRef<eventListenersStatesRefType>({
+    showCodeView,
+    showActionsPanel,
+    needToReloadIframe,
+    iframeSrc,
     iframeRefState,
     iframeRefRef,
     nodeTreeRef,
@@ -50,19 +83,111 @@ export const IFrame = () => {
     isEditingRef,
     hoveredItemRef,
     selectedItemsRef,
+    activePanel,
+    osType,
+    cmdkReferenceData,
+    isCodeTyping,
+    formatCode,
   });
+
+  const { onKeyDown, onKeyUp, handlePanelsToggle, handleZoomKeyDown } =
+    useCmdk();
   const { onMouseEnter, onMouseMove, onMouseLeave, onClick, onDblClick } =
-    useMouseEvents({
-      iframeRefRef,
-      nodeTreeRef,
-      selectedItemsRef,
-      contentEditableUidRef,
-      isEditingRef,
-    });
+    useMouseEvents(eventListenersStatesRef);
 
   useEffect(() => {
     allPanelsClosedRef.current = !showActionsPanel && !showCodeView;
   }, [showActionsPanel, showCodeView]);
+
+  const addHtmlNodeEventListeners = useCallback(
+    (htmlNode: HTMLElement) => {
+      // define event handlers
+
+      // enable cmdk
+      htmlNode.addEventListener("keydown", (e: KeyboardEvent) => {
+        onKeyDown(e, eventListenersStatesRef);
+        handleZoomKeyDown(e, eventListenersStatesRef);
+        handlePanelsToggle(e, eventListenersStatesRef);
+      });
+
+      htmlNode.addEventListener("mouseenter", () => {
+        onMouseEnter();
+      });
+      htmlNode.addEventListener("mousemove", (e: MouseEvent) => {
+        onMouseMove(e);
+      });
+      htmlNode.addEventListener("mouseleave", () => {
+        onMouseLeave();
+      });
+
+      htmlNode.addEventListener("click", (e: MouseEvent) => {
+        e.preventDefault();
+        onClick(e);
+      });
+      htmlNode.addEventListener("dblclick", (e: MouseEvent) => {
+        e.preventDefault();
+        onDblClick(e);
+      });
+      htmlNode.addEventListener("keyup", (e: KeyboardEvent) => {
+        e.preventDefault();
+        onKeyUp(e, eventListenersStatesRef);
+      });
+    },
+    [
+      onKeyDown,
+      onMouseEnter,
+      onMouseMove,
+      onMouseLeave,
+      onClick,
+      onDblClick,
+      onKeyUp,
+    ],
+  );
+
+  const iframeOnload = useCallback(() => {
+    LogAllow && console.log("iframe loaded");
+
+    const _document = iframeRefState?.contentWindow?.document;
+    const htmlNode = _document?.documentElement;
+    const headNode = _document?.head;
+    setDocument(_document);
+    if (htmlNode && headNode) {
+      // add rnbw css
+      const style = _document.createElement("style");
+      style.textContent = styles;
+      style.setAttribute(PreserveRnbwNode, "true");
+      headNode.appendChild(style);
+
+      // add image-validator js
+      const js = _document.createElement("script");
+      js.setAttribute("image-validator", "true");
+      js.setAttribute(PreserveRnbwNode, "true");
+      js.textContent = jss;
+      headNode.appendChild(js);
+
+      // define event handlers
+      addHtmlNodeEventListeners(htmlNode);
+
+      // disable contextmenu
+      _document.addEventListener("contextmenu", (e: MouseEvent) => {
+        e.preventDefault();
+      });
+    }
+
+    // mark selected elements on load
+    markSelectedElements(iframeRefState, selectedItemsRef.current, nodeTree);
+
+    dispatch(setIframeLoading(false));
+    project.context === "local" && dispatch(setLoadingFalse());
+  }, [
+    iframeRefState,
+    addHtmlNodeEventListeners,
+    selectedItemsRef,
+    nodeTree,
+    dispatch,
+    project,
+  ]);
+
   // init iframe
   useEffect(() => {
     setIframeRefRef(iframeRefState);
@@ -70,72 +195,14 @@ export const IFrame = () => {
       project.context === "local" && dispatch(setLoadingTrue());
       dispatch(setIframeLoading(true));
 
-      iframeRefState.onload = () => {
-        LogAllow && console.log("iframe loaded");
-
-        const _document = iframeRefState?.contentWindow?.document;
-        const htmlNode = _document?.documentElement;
-        const headNode = _document?.head;
-        setDocument(_document);
-        if (htmlNode && headNode) {
-          // enable cmdk
-          htmlNode.addEventListener("keydown", (e: KeyboardEvent) => {
-            onKeyDown(e, allPanelsClosedRef.current);
-          });
-
-          // add rnbw css
-          const style = _document.createElement("style");
-          style.textContent = styles;
-          style.setAttribute(PreserveRnbwNode, "true");
-          headNode.appendChild(style);
-
-          // add image-validator js
-          const js = _document.createElement("script");
-          js.setAttribute("image-validator", "true");
-          js.setAttribute(PreserveRnbwNode, "true");
-          js.textContent = jss;
-          headNode.appendChild(js);
-
-          // define event handlers
-          htmlNode.addEventListener("mouseenter", () => {
-            onMouseEnter();
-          });
-          htmlNode.addEventListener("mousemove", (e: MouseEvent) => {
-            onMouseMove(e);
-          });
-          htmlNode.addEventListener("mouseleave", () => {
-            onMouseLeave();
-          });
-
-          htmlNode.addEventListener("click", (e: MouseEvent) => {
-            e.preventDefault();
-            onClick(e);
-          });
-          htmlNode.addEventListener("dblclick", (e: MouseEvent) => {
-            e.preventDefault();
-            onDblClick(e);
-          });
-          htmlNode.addEventListener("keyup", (e: KeyboardEvent) => {
-            e.preventDefault();
-            onKeyUp(e);
-          });
-          // disable contextmenu
-          _document.addEventListener("contextmenu", (e: MouseEvent) => {
-            e.preventDefault();
-          });
-        }
-
-        // mark selected elements on load
-        markSelectedElements(
-          iframeRefState,
-          selectedItemsRef.current,
-          nodeTree,
-        );
-
-        dispatch(setIframeLoading(false));
-        project.context === "local" && dispatch(setLoadingFalse());
-      };
+      iframeRefState.onload = iframeOnload;
     }
+    return () => {
+      // Cleanup function to remove event listener
+      if (iframeRefState) {
+        iframeRefState.onload = null;
+      }
+    };
   }, [iframeRefState]);
 
   // reload iframe
@@ -187,6 +254,43 @@ export const IFrame = () => {
     }
   }, [iframeRefState, document, needToReloadIframe, validNodeTree]);
 
+  useEffect(() => {
+    eventListenersStatesRef.current = {
+      showCodeView,
+      showActionsPanel,
+      needToReloadIframe,
+      iframeSrc,
+      iframeRefState,
+      iframeRefRef,
+      nodeTreeRef,
+      contentEditableUidRef,
+      isEditingRef,
+      hoveredItemRef,
+      selectedItemsRef,
+      activePanel,
+      osType,
+      cmdkReferenceData,
+      isCodeTyping,
+      formatCode,
+    };
+  }, [
+    showActionsPanel,
+    showCodeView,
+    needToReloadIframe,
+    iframeSrc,
+    iframeRefState,
+    iframeRefRef,
+    nodeTreeRef,
+    contentEditableUidRef,
+    isEditingRef,
+    hoveredItemRef,
+    selectedItemsRef,
+    activePanel,
+    osType,
+    cmdkReferenceData,
+    isCodeTyping,
+    formatCode,
+  ]);
   return useMemo(() => {
     return (
       <>

--- a/src/components/main/stageView/iFrame/hooks/useCmdk.ts
+++ b/src/components/main/stageView/iFrame/hooks/useCmdk.ts
@@ -206,8 +206,13 @@ export const useCmdk = () => {
       e: KeyboardEvent,
       eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
     ) => {
-      const { osType, hoveredItemRef, selectedItemsRef, nodeTreeRef } =
-        eventListenerRef.current;
+      const {
+        osType,
+        hoveredItemRef,
+        selectedItemsRef,
+        nodeTreeRef,
+        hoveredNodeUid,
+      } = eventListenerRef.current;
       if (
         !hoveredItemRef.current ||
         selectedItemsRef.current.includes(hoveredItemRef.current)
@@ -222,8 +227,8 @@ export const useCmdk = () => {
           uids: [hoveredItemRef.current],
           nodeTree: nodeTreeRef.current,
         });
-
-        dispatch(setHoveredNodeUid(targetUid[0]));
+        if (targetUid[0] !== hoveredNodeUid)
+          dispatch(setHoveredNodeUid(targetUid[0]));
       }
     },
     [],

--- a/src/components/main/stageView/iFrame/hooks/useCmdk.ts
+++ b/src/components/main/stageView/iFrame/hooks/useCmdk.ts
@@ -1,96 +1,113 @@
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useContext, useRef } from "react";
 
 import { useDispatch } from "react-redux";
 
 import { LogAllow } from "@_constants/global";
-import { TNodeTreeData, TNodeUid } from "@_node/types";
 import { MainContext } from "@_redux/main";
 import { setCurrentCommand } from "@_redux/main/cmdk";
-import { useAppState } from "@_redux/useAppState";
 import { getCommandKey } from "@_services/global";
 import { TCmdkKeyMap } from "@_types/main";
 
 import { editHtmlContent, getBodyChild } from "../helpers";
 import { setShowActionsPanel, setShowCodeView } from "@_redux/main/processor";
+import { eventListenersStatesRefType } from "../IFrame";
 import { setHoveredNodeUid } from "@_redux/main/nodeTree";
 
-interface IUseCmdkProps {
-  iframeRefState: HTMLIFrameElement | null;
-  iframeRefRef: React.MutableRefObject<HTMLIFrameElement | null>;
-  nodeTreeRef: React.MutableRefObject<TNodeTreeData>;
-  contentEditableUidRef: React.MutableRefObject<TNodeUid>;
-  isEditingRef: React.MutableRefObject<boolean>;
-  hoveredItemRef: React.MutableRefObject<TNodeUid>;
-  selectedItemsRef: React.MutableRefObject<TNodeUid[]>;
-}
-
-export const useCmdk = ({
-  iframeRefState,
-  iframeRefRef,
-  nodeTreeRef,
-  contentEditableUidRef,
-  isEditingRef,
-  hoveredItemRef,
-  selectedItemsRef,
-}: IUseCmdkProps) => {
+export const useCmdk = () => {
   const dispatch = useDispatch();
-  const { osType, cmdkReferenceData, activePanel, isCodeTyping } =
-    useAppState();
-  const { monacoEditorRef } = useContext(MainContext);
-  const [zoomLevel, setZoomLevel] = useState(1);
-  const activePanelRef = useRef(activePanel);
-  const { formatCode } = useAppState();
 
-  useEffect(() => {
-    activePanelRef.current = activePanel;
-  }, [activePanel]);
+  const { monacoEditorRef } = useContext(MainContext);
+  const zoomLevelRef = useRef(1);
 
   const setZoom = useCallback(
-    (level: number) => {
-      setZoomLevel(level);
+    (level: number, iframeRefState: HTMLIFrameElement | null) => {
+      zoomLevelRef.current = level;
       if (!iframeRefState) return;
       iframeRefState.style.transform = `scale(${level})`;
       iframeRefState.style.transformOrigin = `top ${
         level > 1 ? "left" : "center"
       }`;
     },
-    [iframeRefState],
+    [],
   );
 
   const handleZoomKeyDown = useCallback(
-    (event: KeyboardEvent) => {
+    (
+      event: KeyboardEvent,
+      eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+    ) => {
+      const { activePanel, iframeRefState, isEditingRef, isCodeTyping } =
+        eventListenerRef.current;
       if (
-        activePanelRef.current === "code" ||
-        activePanelRef.current === "settings" ||
+        activePanel === "code" ||
+        activePanel === "settings" ||
         isCodeTyping ||
         isEditingRef.current
       )
         return;
 
       const key = event.key;
+      let _zoomLevel = zoomLevelRef.current;
 
       switch (key) {
         case "0":
         case "Escape":
-          setZoom(1);
+          setZoom(1, iframeRefState);
           break;
         case "+":
-          setZoom(zoomLevel + 0.25);
+          _zoomLevel = _zoomLevel + 0.25;
+          setZoom(_zoomLevel, iframeRefState);
           break;
         case "-":
-          setZoom(zoomLevel <= 0.25 ? zoomLevel : zoomLevel - 0.25);
+          if (_zoomLevel > 0.25) {
+            _zoomLevel = _zoomLevel - 0.25;
+          }
+          setZoom(_zoomLevel, iframeRefState);
           break;
         default:
           if (key >= "1" && key <= "9") {
-            setZoom(Number(`0.${key}`));
+            setZoom(Number(`0.${key}`), iframeRefState);
           }
           break;
       }
     },
-    [setZoom, zoomLevel, activePanelRef.current, isCodeTyping, iframeRefState],
+    [setZoom, zoomLevelRef.current],
+  );
+
+  const handlePanelsToggle = useCallback(
+    (
+      event: KeyboardEvent,
+      eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+    ) => {
+      const { isEditingRef, showActionsPanel, showCodeView } =
+        eventListenerRef.current;
+      if (isEditingRef.current) return;
+      if (event.code === "Escape") {
+        if (!showActionsPanel && !showCodeView) {
+          dispatch(setShowActionsPanel(true));
+          dispatch(setShowCodeView(true));
+        } else {
+          dispatch(setShowActionsPanel(false));
+          dispatch(setShowCodeView(false));
+        }
+      }
+    },
+    [],
   );
   const onKeyDown = useCallback(
-    (e: KeyboardEvent, allPanelsClosed: boolean) => {
+    (
+      e: KeyboardEvent,
+      eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+    ) => {
+      const {
+        isEditingRef,
+        osType,
+        cmdkReferenceData,
+        iframeRefRef,
+        contentEditableUidRef,
+        nodeTreeRef,
+        formatCode,
+      } = eventListenerRef.current;
       // cmdk obj for the current command
       const cmdk: TCmdkKeyMap = {
         cmd: getCommandKey(e, osType),
@@ -173,16 +190,6 @@ export const useCmdk = ({
           }
         }
       } else {
-        handleZoomKeyDown(e);
-        if (e.code === "Escape") {
-          if (allPanelsClosed) {
-            dispatch(setShowActionsPanel(true));
-            dispatch(setShowCodeView(true));
-          } else {
-            dispatch(setShowActionsPanel(false));
-            dispatch(setShowCodeView(false));
-          }
-        }
         if (action) {
           LogAllow && console.log("action to be run by cmdk: ", action);
           dispatch(setCurrentCommand({ action }));
@@ -191,11 +198,16 @@ export const useCmdk = ({
 
       !isEditingRef.current && action && e.preventDefault();
     },
-    [osType, cmdkReferenceData, iframeRefState],
+    [],
   );
 
   const onKeyUp = useCallback(
-    (e: KeyboardEvent) => {
+    (
+      e: KeyboardEvent,
+      eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+    ) => {
+      const { osType, hoveredItemRef, selectedItemsRef, nodeTreeRef } =
+        eventListenerRef.current;
       if (
         !hoveredItemRef.current ||
         selectedItemsRef.current.includes(hoveredItemRef.current)
@@ -214,7 +226,7 @@ export const useCmdk = ({
         dispatch(setHoveredNodeUid(targetUid[0]));
       }
     },
-    [osType],
+    [],
   );
-  return { onKeyDown, onKeyUp };
+  return { onKeyDown, onKeyUp, handleZoomKeyDown, handlePanelsToggle };
 };

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -49,11 +49,12 @@ export const useMouseEvents = () => {
         contentEditableUidRef,
         iframeRefRef,
         osType,
+        hoveredNodeUid,
       } = eventListenerRef.current;
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
       if (!uid) return;
       if (getCommandKey(e, osType)) {
-        dispatch(setHoveredNodeUid(uid));
+        if (hoveredNodeUid !== uid) dispatch(setHoveredNodeUid(uid));
         iframeRefRef.current?.focus();
       } else {
         const isSelectedChild = isChild({
@@ -67,7 +68,9 @@ export const useMouseEvents = () => {
             ? [selectedItemsRef.current[0]]
             : getBodyChild({ uids: [uid], nodeTree: nodeTreeRef.current });
 
-        dispatch(setHoveredNodeUid(targetUids[0]));
+        if (targetUids[0] !== hoveredNodeUid) {
+          dispatch(setHoveredNodeUid(targetUids[0]));
+        }
       }
     },
     [],
@@ -181,6 +184,7 @@ export const useMouseEvents = () => {
         htmlReferenceData,
         fileTree,
         validNodeTree,
+        hoveredNodeUid,
       } = eventListenerRef.current;
       const ele = e.target as HTMLElement;
       const uid: TNodeUid | null = ele.getAttribute(StageNodeIdAttr);
@@ -218,7 +222,7 @@ export const useMouseEvents = () => {
           !targetUid ? uid : targetUid,
         ]);
         !same && dispatch(setSelectedNodeUids([!targetUid ? uid : targetUid]));
-        dispatch(setHoveredNodeUid(""));
+        if (hoveredNodeUid !== "") dispatch(setHoveredNodeUid(""));
 
         if (targetUid) return;
         if (!ele.getAttribute("rnbw-text-element")) return;

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -6,7 +6,6 @@ import { ShortDelay } from "@_constants/main";
 import { StageNodeIdAttr } from "@_node/file";
 import { getValidNodeUids } from "@_node/helpers";
 import { THtmlNodeData } from "@_node/node";
-import { TNodeTreeData, TNodeUid } from "@_node/types";
 import { MainContext } from "@_redux/main";
 import { setHoveredNodeUid } from "@_redux/main/nodeTree";
 import { setSelectedNodeUids } from "@_redux/main/nodeTree/event";
@@ -28,22 +27,27 @@ import {
 } from "@_pages/main/helper";
 import { useAppState } from "@_redux/useAppState";
 import { getCommandKey } from "@_services/global";
+import { eventListenersStatesRefType } from "../IFrame";
+import { TNodeUid } from "@_node/index";
 
-interface IUseMouseEventsProps {
-  iframeRefRef: React.MutableRefObject<HTMLIFrameElement | null>;
-  nodeTreeRef: React.MutableRefObject<TNodeTreeData>;
-  selectedItemsRef: React.MutableRefObject<TNodeUid[]>;
-  contentEditableUidRef: React.MutableRefObject<TNodeUid>;
-  isEditingRef: React.MutableRefObject<boolean>;
-}
+// interface IUseMouseEventsProps {
+//   iframeRefRef: React.MutableRefObject<HTMLIFrameElement | null>;
+//   nodeTreeRef: React.MutableRefObject<TNodeTreeData>;
+//   selectedItemsRef: React.MutableRefObject<TNodeUid[]>;
+//   contentEditableUidRef: React.MutableRefObject<TNodeUid>;
+//   isEditingRef: React.MutableRefObject<boolean>;
+// }
 
-export const useMouseEvents = ({
-  iframeRefRef,
-  nodeTreeRef,
-  selectedItemsRef,
-  contentEditableUidRef,
-  isEditingRef,
-}: IUseMouseEventsProps) => {
+export const useMouseEvents = (
+  eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+) => {
+  const {
+    iframeRefRef,
+    nodeTreeRef,
+    selectedItemsRef,
+    contentEditableUidRef,
+    isEditingRef,
+  } = eventListenerRef.current;
   const dispatch = useDispatch();
   const { monacoEditorRef } = useContext(MainContext);
   const {
@@ -53,6 +57,7 @@ export const useMouseEvents = ({
     formatCode,
     htmlReferenceData,
     osType,
+    activePanel,
   } = useAppState();
 
   const mostRecentClickedNodeUidRef = useRef<TNodeUid>(""); //This is used because dbl clikc event was not able to receive the uid of the node that was clicked
@@ -90,7 +95,7 @@ export const useMouseEvents = ({
   // click, dblclick handlers
   const onClick = useCallback(
     (e: MouseEvent) => {
-      dispatch(setActivePanel("stage"));
+      if (activePanel !== "stage") dispatch(setActivePanel("stage"));
 
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
       if (!uid) return;
@@ -157,7 +162,7 @@ export const useMouseEvents = ({
         });
       }
     },
-    [validNodeTree, nodeTreeRef, selectedItemsRef, osType],
+    [activePanel, formatCode, monacoEditorRef, osType, validNodeTree],
   );
 
   const debouncedSelectAllText = useCallback(

--- a/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
+++ b/src/components/main/stageView/iFrame/hooks/useMouseEvents.ts
@@ -25,47 +25,31 @@ import {
   isWebComponentDblClicked,
   onWebComponentDblClick,
 } from "@_pages/main/helper";
-import { useAppState } from "@_redux/useAppState";
+
 import { getCommandKey } from "@_services/global";
 import { eventListenersStatesRefType } from "../IFrame";
 import { TNodeUid } from "@_node/index";
 
-// interface IUseMouseEventsProps {
-//   iframeRefRef: React.MutableRefObject<HTMLIFrameElement | null>;
-//   nodeTreeRef: React.MutableRefObject<TNodeTreeData>;
-//   selectedItemsRef: React.MutableRefObject<TNodeUid[]>;
-//   contentEditableUidRef: React.MutableRefObject<TNodeUid>;
-//   isEditingRef: React.MutableRefObject<boolean>;
-// }
-
-export const useMouseEvents = (
-  eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
-) => {
-  const {
-    iframeRefRef,
-    nodeTreeRef,
-    selectedItemsRef,
-    contentEditableUidRef,
-    isEditingRef,
-  } = eventListenerRef.current;
+export const useMouseEvents = () => {
   const dispatch = useDispatch();
   const { monacoEditorRef } = useContext(MainContext);
-  const {
-    fileTree,
-    validNodeTree,
-    fExpandedItemsObj: expandedItemsObj,
-    formatCode,
-    htmlReferenceData,
-    osType,
-    activePanel,
-  } = useAppState();
 
   const mostRecentClickedNodeUidRef = useRef<TNodeUid>(""); //This is used because dbl clikc event was not able to receive the uid of the node that was clicked
 
   // hoveredNodeUid
   const onMouseEnter = useCallback(() => {}, []);
   const onMouseMove = useCallback(
-    (e: MouseEvent) => {
+    (
+      e: MouseEvent,
+      eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+    ) => {
+      const {
+        nodeTreeRef,
+        selectedItemsRef,
+        contentEditableUidRef,
+        iframeRefRef,
+        osType,
+      } = eventListenerRef.current;
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
       if (!uid) return;
       if (getCommandKey(e, osType)) {
@@ -86,7 +70,7 @@ export const useMouseEvents = (
         dispatch(setHoveredNodeUid(targetUids[0]));
       }
     },
-    [validNodeTree, osType],
+    [],
   );
   const onMouseLeave = () => {
     dispatch(setHoveredNodeUid(""));
@@ -94,7 +78,20 @@ export const useMouseEvents = (
 
   // click, dblclick handlers
   const onClick = useCallback(
-    (e: MouseEvent) => {
+    (
+      e: MouseEvent,
+      eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+    ) => {
+      const {
+        nodeTreeRef,
+        selectedItemsRef,
+        contentEditableUidRef,
+        iframeRefRef,
+        isEditingRef,
+        activePanel,
+        osType,
+        formatCode,
+      } = eventListenerRef.current;
       if (activePanel !== "stage") dispatch(setActivePanel("stage"));
 
       const { uid } = getValidElementWithUid(e.target as HTMLElement);
@@ -162,7 +159,7 @@ export const useMouseEvents = (
         });
       }
     },
-    [activePanel, formatCode, monacoEditorRef, osType, validNodeTree],
+    [monacoEditorRef],
   );
 
   const debouncedSelectAllText = useCallback(
@@ -170,7 +167,21 @@ export const useMouseEvents = (
     [],
   );
   const onDblClick = useCallback(
-    (e: MouseEvent) => {
+    (
+      e: MouseEvent,
+      eventListenerRef: React.MutableRefObject<eventListenersStatesRefType>,
+    ) => {
+      const {
+        nodeTreeRef,
+        selectedItemsRef,
+        contentEditableUidRef,
+        isEditingRef,
+        iframeRefRef,
+        fExpandedItemsObj,
+        htmlReferenceData,
+        fileTree,
+        validNodeTree,
+      } = eventListenerRef.current;
       const ele = e.target as HTMLElement;
       const uid: TNodeUid | null = ele.getAttribute(StageNodeIdAttr);
 
@@ -188,7 +199,7 @@ export const useMouseEvents = (
           ) {
             onWebComponentDblClick({
               dispatch,
-              expandedItemsObj,
+              expandedItemsObj: fExpandedItemsObj,
               fileTree,
               validNodeTree,
               wcName: nodeData.nodeName,
@@ -227,17 +238,7 @@ export const useMouseEvents = (
         }
       }
     },
-    [
-      contentEditableUidRef,
-      debouncedSelectAllText,
-      expandedItemsObj,
-      fileTree,
-      htmlReferenceData,
-      nodeTreeRef,
-      mostRecentClickedNodeUidRef.current,
-      selectedItemsRef,
-      validNodeTree,
-    ],
+    [debouncedSelectAllText, mostRecentClickedNodeUidRef.current],
   );
 
   return {


### PR DESCRIPTION
Closes #738 

Basically, what was happening before was that the event handlers were not able to access the latest updated states even if they were wrapped in useCallback with the required state variables as the dependency of the callback.

This was because of the fact that event listeners when attached once with iframeState as true cannot be reassigned with the updated callbacks method.

To solve this we used ref to hold all the state variables required by all the event handlers and pass those ref directly to event handlers.

This way event handlers always hold the value of ref and we can always get access to the latest value by using ref.current that we update in the useEffect of the Iframe component.