### PR TITLE
Make rnbw robust

### DIFF
--- a/src/components/main/codeView/CodeView.tsx
+++ b/src/components/main/codeView/CodeView.tsx
@@ -171,8 +171,8 @@ export default function CodeView() {
   }, [nFocusedItem]);
 
   useEffect(() => {
-    if (isCodeTyping) return;
-    if (nFocusedItem === "") return;
+    if (activePanel === "code" || isCodeTyping || nFocusedItem === "") return;
+
     const monacoEditor = monacoEditorRef.current;
     if (!monacoEditor) return;
     const node = validNodeTree[nFocusedItem];

--- a/src/components/main/codeView/hooks/useEditor.ts
+++ b/src/components/main/codeView/hooks/useEditor.ts
@@ -35,7 +35,7 @@ import { debounce } from "@_pages/main/helper";
 
 const useEditor = () => {
   const dispatch = useDispatch();
-  const { theme: _theme, autoSave, isCodeTyping } = useAppState();
+  const { theme: _theme, autoSave, isCodeTyping, nFocusedItem } = useAppState();
   const {
     monacoEditorRef,
     setMonacoEditorRef,
@@ -158,8 +158,8 @@ const useEditor = () => {
             : null,
         ),
       );
-      dispatch(setIsCodeTyping(false));
       autoSave && debouncedAutoSave();
+      dispatch(setIsCodeTyping(false));
     },
     [debouncedAutoSave, autoSave],
   );
@@ -184,8 +184,8 @@ const useEditor = () => {
   const handleOnChange = useCallback(
     (value: string | undefined) => {
       if (value === undefined) return;
-      dispatch(setIsCodeTyping(true));
-      dispatch(focusNodeTreeNode(""));
+      !isCodeTyping && dispatch(setIsCodeTyping(true));
+      nFocusedItem !== "" && dispatch(focusNodeTreeNode(""));
       if (isCodeEditingView.current) {
         longDebouncedOnChange(value);
         isCodeEditingView.current = false;

--- a/src/components/main/codeView/hooks/useEditor.ts
+++ b/src/components/main/codeView/hooks/useEditor.ts
@@ -129,10 +129,8 @@ const useEditor = () => {
       );
 
       editor.onDidChangeCursorPosition((event) => {
-        if (isCodeTyping) {
-          (event.source === "mouse" || event.source === "keyboard") &&
-            setCodeSelection();
-        }
+        (event.source === "mouse" || event.source === "keyboard") &&
+          setCodeSelection();
       });
     },
     [setCodeSelection],

--- a/src/components/main/stageView/iFrame/IFrame.tsx
+++ b/src/components/main/stageView/iFrame/IFrame.tsx
@@ -72,9 +72,11 @@ export const IFrame = () => {
 
       // enable cmdk
       htmlNode.addEventListener("keydown", (e: KeyboardEvent) => {
+        //handlePanelsToggle should be called before onKeyDown as on onKeyDown the contentEditiable editing is set to false and the panels are toggled. But we don't need to toggle the panels if the user is editing the contentEditable
+        handlePanelsToggle(e, eventListenersStatesRef);
+
         onKeyDown(e, eventListenersStatesRef);
         handleZoomKeyDown(e, eventListenersStatesRef);
-        handlePanelsToggle(e, eventListenersStatesRef);
       });
 
       htmlNode.addEventListener("mouseenter", () => {
@@ -236,14 +238,15 @@ export const IFrame = () => {
     needToReloadIframe,
 
     iframeRefState,
-    iframeRefRef,
-    nodeTreeRef,
-    contentEditableUidRef,
-    isEditingRef,
-    hoveredItemRef,
-    selectedItemsRef,
+    iframeRefRef.current,
+    nodeTreeRef.current,
+    contentEditableUidRef.current,
+    isEditingRef.current,
+    hoveredItemRef.current,
+    selectedItemsRef.current,
     appState,
   ]);
+
   return useMemo(() => {
     return (
       <>


### PR DESCRIPTION
- fix: escape hiding the panels and update the dep of useEffect to have ref.current instead of ref as only ref doesn't trigger useEffect.
- fix: bring back select nodes from codeview
- fix: cursor jumping when typing in codeview
- feat: conditional state update

Closes #718 