### PR TITLE
feat: Changes related to files and stage

### DIFF
--- a/src/pages/main/helper.ts
+++ b/src/pages/main/helper.ts
@@ -33,6 +33,7 @@ import { TFileNodeData, TFileNodeTreeData, createURLPath } from "@_node/index";
 import {
   setActivePanel,
   setNavigatorDropdownType,
+  setShowFilePanel,
 } from "@_redux/main/processor";
 import { AnyFunction } from "./types";
 import { toast } from "react-toastify";
@@ -391,6 +392,7 @@ export const onWebComponentDblClick = ({
             } else {
               dispatch(setInitialFileUidToOpen(fileTree[x].uid));
               dispatch(setNavigatorDropdownType("project"));
+              dispatch(setShowFilePanel(true));
               dispatch(setActivePanel("code"));
               filePath = createURLPath(
                 fileTree[x].uid,


### PR DESCRIPTION
-  Removed loading state update from various part of the code where it felt unnecessary
- Stage will always show last html file opened
- On click of stage (to be implemented for clicking node) switch make the current file the last index.html
- When a file is opened it should reflect on url, codeview. If it's an html file it will reflect on stageview also.
- When reloading, the path should reset to "root" of rnbw "/"
- File panel should be visible when opening web-component
- Removing redundant states such as `isWcOpen` and `needToReloadIframe`