### PR TITLE
709 search: Search project files from jumpstart. 

### DIFF
--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -448,6 +448,12 @@ export default function MainPage() {
                                       projectHandler,
                                     );
                                 } else if (
+                                  currentCmdkPage === "Jumpstart" &&
+                                  command.Group === "Files"
+                                ) {
+                                  const pathFile = command.Name;
+                                  navigate(pathFile);
+                                } else if (
                                   (currentCmdkPage === "Add" &&
                                     command.Group === "Recent") ||
                                   (currentCmdkPage === "Turn into" &&

--- a/src/pages/main/hooks/useCmdkReferenceData.ts
+++ b/src/pages/main/hooks/useCmdkReferenceData.ts
@@ -115,7 +115,36 @@ export const useCmdkReferenceData = ({
               LogAllow && console.error("failed to load last session");
             }
           }
-
+          if (
+            groupName === "Projects" &&
+            _cmdkRefJumpstartData["Files"] === undefined
+          ) {
+            _cmdkRefJumpstartData["Files"] = [];
+            if (fileTree && cmdkSearchContent !== "") {
+              for (const key in fileTree) {
+                if (fileTree[key].isEntity) {
+                  const pathFile = fileTree[key].data.path;
+                  const _fileCommand = {
+                    Name: pathFile,
+                    Icon: "page",
+                    Description: "",
+                    "Keyboard Shortcut": [
+                      {
+                        cmd: false,
+                        shift: false,
+                        alt: false,
+                        key: "",
+                        click: false,
+                      },
+                    ],
+                    Group: "Files",
+                    Context: key,
+                  } as TCmdkReference;
+                  _cmdkRefJumpstartData["Files"].push(_fileCommand);
+                }
+              }
+            }
+          }
           _cmdkReferenceData[_command["Name"]] = _command;
         }),
       );
@@ -162,7 +191,7 @@ export const useCmdkReferenceData = ({
 
       dispatch(removeRunningAction());
     })();
-  }, []);
+  }, [fileTree, cmdkSearchContent]);
 
   const cmdkReferenceRecentProject = useMemo(() => {
     const _cmdkReferenceRecentProject: TCmdkReference[] = [];


### PR DESCRIPTION
#709 - Search  


**New Feature :**  Search project files from jumpstart. 

_Updated the file `useCmdkReferenceData.ts`_

- **File Processing**:  For each file in the `fileTree` object, if the file is an entity and there is a search content in `cmdkSearchContent`, a new` _fileCommand` object is created. This object includes the file's path as the name, a default icon "page" , the group name "Files", and the key from the fileTree as the context.

- **File Addition**: The newly created `_fileCommand` object is then added to the Files group in the _cmdkRefJumpstartData object. This allows the files to be searched and interacted with through the jumpstart interface.

_Updated the file `MainPage.tsx`_

**File Navigation:** When a file is clicked from the Jumpstart, the application now navigates to the selected file's path. This is achieved by checking if the `currentCmdkPage` is "Jumpstart" and the `command.Group` is "Files", then navigating to the file's path.

