### PR TITLE
feat: add file searching functionality with s as a shortcut key

### DIFF
--- a/src/_ref/cmdk.ref/Jumpstart.csv
+++ b/src/_ref/cmdk.ref/Jumpstart.csv
@@ -7,3 +7,4 @@ Community,people,Talk with people,,Help
 Theme,,Switch themes,m,Settings
 Autosave,,Switch autosave,,Settings
 Word Wrap,,Switch word wrap,alt+z,Settings
+Search,search,Search files,s,Projects

--- a/src/pages/main/cmdkPage/CommandDialog.tsx
+++ b/src/pages/main/cmdkPage/CommandDialog.tsx
@@ -178,7 +178,7 @@ export const CommandDialog = () => {
       onOpenChange={(open: boolean) => dispatch(setCmdkOpen(open))}
       onKeyDown={onKeyDown}
       filter={(value: string, search: string) => {
-        return value.includes(search) !== false ? 1 : 0;
+        return value.includes(search?.toLowerCase()) !== false ? 1 : 0;
       }}
       loop={true}
       label={currentCmdkPage}

--- a/src/pages/main/cmdkPage/constants.ts
+++ b/src/pages/main/cmdkPage/constants.ts
@@ -3,6 +3,7 @@ export const PLACEHOLDERS = {
   Jumpstart: "Jumpstart...",
   Actions: "Do something...",
   Add: "Add something...",
+  Search: "Search...",
   "Turn into": "Turn into...",
 };
 
@@ -16,7 +17,7 @@ export const COMMANDS_TO_KEEP_MODAL_OPEN = [
 ];
 
 // pages that can't be opened by other cmdk from within itself
-export const SINGLE_CMDK_PAGE = ["Jumpstart", "Add", "Turn into"];
+export const SINGLE_CMDK_PAGE = ["Jumpstart", "Add", "Turn into", "Search"];
 
 // pages can be opened from other cmdk
-export const DEEP_CMDK_PAGE = ["Add", "Turn into"];
+export const DEEP_CMDK_PAGE = ["Add", "Turn into", "Search"];

--- a/src/pages/main/helper.ts
+++ b/src/pages/main/helper.ts
@@ -37,6 +37,7 @@ import { AnyFunction } from "./types";
 import { toast } from "react-toastify";
 import { NavigateFunction } from "react-router-dom";
 import { TFilesReference } from "@rnbws/rfrncs.design";
+import { FileNode } from "./types";
 
 export const addDefaultCmdkActions = (
   cmdkReferenceData: TCmdkReferenceData,
@@ -69,6 +70,23 @@ export const addDefaultCmdkActions = (
         shift: false,
         alt: false,
         key: "KeyJ",
+        click: false,
+      },
+    ],
+    Group: "default",
+    Context: "all",
+  };
+  // Search
+  cmdkReferenceData["Search"] = {
+    Name: "Search",
+    Icon: "",
+    Description: "",
+    "Keyboard Shortcut": [
+      {
+        cmd: false,
+        shift: false,
+        alt: false,
+        key: "KeyS",
         click: false,
       },
     ],
@@ -459,4 +477,41 @@ export function debounce<F extends AnyFunction>(
 
 export const getObjKeys = <T>(obj: { [key: string]: T }): string[] => {
   return Object.keys(obj);
+};
+
+export const convertToFileNodes = (data: TFileNodeTreeData): FileNode[] => {
+  const result: FileNode[] = [];
+  for (const key in data) {
+    const node = data[key];
+    if (node.data.kind === "file") {
+      result.push({
+        type: "file",
+        name: node.data.name,
+      });
+    }
+  }
+  return result;
+};
+export const filterFiles = (
+  fileTree: TFileNodeTreeData,
+  query: string,
+): string[] => {
+  const results: string[] = [];
+  const fileNodes = convertToFileNodes(fileTree);
+
+  function searchTree(node: FileNode, path: string = "") {
+    if (
+      node.type === "file" &&
+      node.name.toLowerCase().includes(query.toLowerCase())
+    ) {
+      results.push(`${path}/${node.name}`);
+    } else if (node.type === "directory" && node.children) {
+      node.children.forEach((child) =>
+        searchTree(child, `${path}/${node.name}`),
+      );
+    }
+  }
+
+  fileNodes.forEach((root) => searchTree(root));
+  return results;
 };

--- a/src/pages/main/hooks/useCmdk.ts
+++ b/src/pages/main/hooks/useCmdk.ts
@@ -84,6 +84,10 @@ export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
     if (cmdkOpen) return;
     dispatch(setCmdkPages(["Jumpstart"]));
   }, [cmdkOpen]);
+  const onSearch = useCallback(() => {
+    if (cmdkOpen) return;
+    dispatch(setCmdkPages(["Search"]));
+  }, [cmdkOpen]);
   const onNew = useCallback(async () => {
     if (!confirmFileChanges(fileTree)) return;
 
@@ -334,6 +338,9 @@ export const useCmdk = ({ cmdkReferenceData, importProject }: IUseCmdk) => {
     switch (currentCommand.action) {
       case "Jumpstart":
         onJumpstart();
+        break;
+      case "Search":
+        onSearch();
         break;
       case "New":
         onNew();

--- a/src/pages/main/hooks/useCmdkReferenceData.ts
+++ b/src/pages/main/hooks/useCmdkReferenceData.ts
@@ -25,6 +25,7 @@ import {
   elementsCmdk,
   fileCmdk,
   getKeyObjectsFromCommand,
+  filterFiles,
 } from "../helper";
 import { useDispatch } from "react-redux";
 import { setCmdkReferenceData } from "@_redux/main/cmdk";
@@ -261,11 +262,56 @@ export const useCmdkReferenceData = ({
     return data;
   }, [validNodeTree, nFocusedItem, htmlReferenceData]);
 
+  const cmdkReferenceSearch = useMemo<TCmdkGroupData>(() => {
+    const data: TCmdkGroupData = {
+      Files: [],
+      Elements: [],
+      Recent: [],
+    };
+
+    // Filter files based on search content
+    if (cmdkSearchContent) {
+      const filteredFiles = filterFiles(fileTree, cmdkSearchContent);
+      filteredFiles.forEach((file) => {
+        data["Files"].push({
+          Featured: false,
+          Name: file,
+          Icon: "", // Can add appropriate icon here
+          Description: "",
+          "Keyboard Shortcut": [
+            {
+              cmd: false,
+              shift: false,
+              alt: false,
+              key: "",
+              click: false,
+            },
+          ],
+          Group: "Files",
+          Context: "file",
+        });
+      });
+    }
+
+    // Recent
+    delete data["Recent"];
+
+    return data;
+  }, [
+    fileTree,
+    fFocusedItem,
+    nodeTree,
+    nFocusedItem,
+    htmlReferenceData,
+    cmdkSearchContent,
+  ]);
+
   return {
     Jumpstart: cmdkReferenceJumpstart,
     Actions: cmdkReferenceActions,
     Recent: cmdkReferenceRecentProject,
     Add: cmdkReferenceAdd,
     "Turn into": cmdkReferenceRename,
+    Search: cmdkReferenceSearch,
   };
 };

--- a/src/pages/main/types.ts
+++ b/src/pages/main/types.ts
@@ -1,8 +1,15 @@
 import { ReactNode } from "react";
+
 export type ResizablePanelsProps = {
   actionPanel: ReactNode;
   stageView: ReactNode;
   codeView: ReactNode;
+};
+
+export type FileNode = {
+  type: "file" | "directory";
+  name: string;
+  children?: FileNode[] | undefined;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
**Issue this PR resolves** : [New Feature : Search project files from jumpstart.](https://github.com/rnbwdev/rnbw/issues/709)


**Summary:**
- This PR implements a new Search bar, which can be activated by pressing "s", using `useCmdk`.
- After opening Search bar, when we type something in it, it will look through the files and find the files with the matching name using `useCmdkReferenceSearch`.

**Extras**
- added `search?.toLowerCase()` for all the command dialogs, so it does not consider case sensitivity.

**Recording of the work output**

https://github.com/rnbwdev/rnbw/assets/21654339/8a042969-7c04-45ed-bd01-ab2573dfa70e

