### PR TITLE
Rnbw api

### DIFF
--- a/src/components/main/codeView/hooks/useEditor.ts
+++ b/src/components/main/codeView/hooks/useEditor.ts
@@ -220,9 +220,11 @@ const useEditor = () => {
   const handleOnChange = useCallback(
     (value: string | undefined) => {
       if (value === undefined) return;
-      if (!AppstateRef.current.isContentProgrammaticallyChanged) {
-        !AppstateRef.current.isCodeTyping && dispatch(setIsCodeTyping(true));
-      }
+
+      !isCodeTyping && dispatch(setIsCodeTyping(true));
+      // if (!AppstateRef.current.isContentProgrammaticallyChanged) {
+      //   !AppstateRef.current.isCodeTyping && dispatch(setIsCodeTyping(true));
+      // }
       if (isCodeEditingView.current) {
         longDebouncedOnChange(value);
         isCodeEditingView.current = false;

--- a/src/components/main/stageView/iFrame/IFrame.tsx
+++ b/src/components/main/stageView/iFrame/IFrame.tsx
@@ -226,11 +226,12 @@ export const IFrame = () => {
 
             span.appendChild(text);
             span.setAttribute("rnbw-text-element", "true");
-            span.setAttribute(
-              "data-rnbw-stage-node-id",
-              `${filterArr?.length ? filterArr[0] : i}`,
-            );
+            const stageUid = filterArr?.length ? filterArr[0] : i;
 
+            span.setAttribute("data-rnbw-stage-node-id", `${stageUid}`);
+            if (selectedItemsRef.current.includes(`${stageUid}`)) {
+              span.setAttribute("rnbwdev-rnbw-element-select", "true");
+            }
             node.parentNode?.replaceChild(span, node);
           } else if (node.nodeType === Node.ELEMENT_NODE) {
             wrapTextNodes(node as HTMLElement);
@@ -240,7 +241,7 @@ export const IFrame = () => {
 
       wrapTextNodes(iframeDocument.body);
     }
-  }, [iframeRefState, document, validNodeTree]);
+  }, [iframeRefState, document, validNodeTree, selectedItemsRef.current]);
 
   useEffect(() => {
     eventListenersStatesRef.current = {

--- a/src/components/main/stageView/iFrame/hooks/useSyncNode.ts
+++ b/src/components/main/stageView/iFrame/hooks/useSyncNode.ts
@@ -59,17 +59,18 @@ export const useSyncNode = (iframeRef: HTMLIFrameElement | null) => {
     () => getObjKeys(selectedItemsObj),
     [selectedItemsObj],
   );
-  const selectedItemsRef = useRef<TNodeUid[]>(selectedItems);
+  const previousSelectedItemsRef = useRef<TNodeUid[]>(selectedItems);
+
   useEffect(() => {
     // check if it's a new state
-    if (selectedItemsRef.current.length === selectedItems.length) {
+    if (previousSelectedItemsRef.current.length === selectedItems.length) {
       let same = true;
       for (
-        let index = 0, len = selectedItemsRef.current.length;
+        let index = 0, len = previousSelectedItemsRef.current.length;
         index < len;
         ++index
       ) {
-        if (selectedItemsRef.current[index] !== selectedItems[index]) {
+        if (previousSelectedItemsRef.current[index] !== selectedItems[index]) {
           same = false;
           break;
         }
@@ -77,10 +78,22 @@ export const useSyncNode = (iframeRef: HTMLIFrameElement | null) => {
       if (same) return;
     }
 
-    unmarkSelectedElements(iframeRef, selectedItemsRef.current, nodeTree);
-    markSelectedElements(iframeRef, selectedItems, nodeTree);
-    selectedItemsRef.current = [...selectedItems];
+    unmarkSelectedElements(
+      iframeRef,
+      previousSelectedItemsRef.current,
+      nodeTree,
+    );
+    if (selectedItems.length > 0) {
+      markSelectedElements(iframeRef, selectedItems, nodeTree);
+
+      previousSelectedItemsRef.current = [...selectedItems];
+    }
   }, [selectedItems]);
 
-  return { nodeTreeRef, hoveredItemRef, focusedItemRef, selectedItemsRef };
+  return {
+    nodeTreeRef,
+    hoveredItemRef,
+    focusedItemRef,
+    selectedItemsRef: previousSelectedItemsRef,
+  };
 };

--- a/src/pages/main/processor/hooks/useNodeTreeEvent.ts
+++ b/src/pages/main/processor/hooks/useNodeTreeEvent.ts
@@ -74,6 +74,7 @@ export const useNodeTreeEvent = () => {
     didRedo,
     activePanel,
   } = useAppState();
+
   const { parseHtml } = useElementHelper();
   const { iframeRefRef, setMaxNodeUidRef } = useContext(MainContext);
 
@@ -117,10 +118,13 @@ export const useNodeTreeEvent = () => {
         dispatch(removeRunningAction());
         return;
       }
-      const { contentInApp, nodeTree, selectedNodeUids } =
-        ext === "html"
-          ? await parseHtml(currentFileContent, setMaxNodeUidRef)
-          : { contentInApp: "", nodeTree: {}, selectedNodeUids: [] };
+      const {
+        contentInApp,
+        nodeTree,
+        selectedNodeUids: selectedNodeUidsAfterActions,
+      } = ext === "html"
+        ? await parseHtml(currentFileContent, setMaxNodeUidRef)
+        : { contentInApp: "", nodeTree: {}, selectedNodeUids: [] };
 
       fileData.content = currentFileContent;
 

--- a/src/services/useElements.tsx
+++ b/src/services/useElements.tsx
@@ -444,7 +444,7 @@ export default function useElements() {
       }
       helperModel.applyEdits([removeGroupedCodeEdit, addUngroupedCodeEdit]);
     }
-    const code = await PrettyCode(helperModel.getValue());
+    const code = helperModel.getValue();
     if (!skipUpdate) {
       codeViewInstanceModel.setValue(code);
       dispatch(setNeedToSelectNodePaths(allNodePathsToSelect));

--- a/src/services/useElements.tsx
+++ b/src/services/useElements.tsx
@@ -580,7 +580,7 @@ export default function useElements() {
         };
         helperModel.applyEdits([edit]);
       }
-      const code = await PrettyCode(helperModel.getValue());
+      const code = helperModel.getValue();
       await dispatch(setIsContentProgrammaticallyChanged(true));
       codeViewInstanceModel.setValue(code);
       dispatch(setSelectedNodeUids([nFocusedItem]));
@@ -605,7 +605,7 @@ export default function useElements() {
       "",
     );
     const updatedTag = `<${focusedNode.displayName}${attributesString}>`;
-
+    const prettyUpdatedTag = await PrettyCode(updatedTag);
     const { startTag } = focusedNode.data.sourceCodeLocation;
     const edit = {
       range: new Range(
@@ -614,10 +614,10 @@ export default function useElements() {
         startTag.endLine,
         startTag.endCol,
       ),
-      text: updatedTag,
+      text: prettyUpdatedTag,
     };
     helperModel.applyEdits([edit]);
-    const code = await PrettyCode(helperModel.getValue());
+    const code = helperModel.getValue();
     if (!skipUpdate) {
       await findNodeToSelectAfterAction({
         nodeUids: [nFocusedItem],

--- a/src/services/useElementsHelper.tsx
+++ b/src/services/useElementsHelper.tsx
@@ -389,12 +389,14 @@ export const useElementHelper = () => {
   const findNodeToSelectAfterAction = async ({
     nodeUids,
     action,
+    skipUpdate,
   }: {
     nodeUids: string[];
     action: {
       type: "add" | "remove" | "replace";
       tagNames?: string[];
     };
+    skipUpdate?: boolean;
   }) => {
     const uniqueNodePaths: string[] = [];
     if (nodeUids.length === 0) return [];
@@ -489,6 +491,7 @@ export const useElementHelper = () => {
         uniqueNodePaths.push(uniqueNodePathToFocus);
       });
     }
+    if (uniqueNodePaths.length === 0 || skipUpdate) return;
     await dispatch(setNeedToSelectNodePaths(uniqueNodePaths));
     return uniqueNodePaths;
   };

--- a/src/types/elements.types.ts
+++ b/src/types/elements.types.ts
@@ -27,6 +27,16 @@ interface Ipaste {
   pastePosition?: "before" | "after" | "inside";
   skipUpdate?: boolean;
 }
+
+interface Iungroup {
+  uids?: TNodeUid[];
+  skipUpdate?: boolean;
+}
+
+interface Igroup {
+  uids?: TNodeUid[];
+  skipUpdate?: boolean;
+}
 interface Iremove {
   uids?: TNodeUid[];
   skipUpdate?: boolean;
@@ -40,4 +50,14 @@ interface Imove {
   skipUpdate?: boolean;
 }
 
-export { Iadd, Iduplicate, IupdateSettings, Icopy, Ipaste, Iremove, Imove };
+export {
+  Iadd,
+  Iduplicate,
+  IupdateSettings,
+  Icopy,
+  Ipaste,
+  Igroup,
+  Iungroup,
+  Iremove,
+  Imove,
+};


### PR DESCRIPTION
- Covered edge case for select `#text` node after an action is completed. Example: ungrouping a node whose children is a `#text` node
- Improved move operation. Covered case for when moving below siblings.
- Node focus implemented for editing node via stage by double clicking
- Replaced html beautify with prettier in useElements